### PR TITLE
Electrical Jukebox Mute Seçeneği ve Bugfix

### DIFF
--- a/code/datums/proximity_monitor/fields/player_collector.dm
+++ b/code/datums/proximity_monitor/fields/player_collector.dm
@@ -2,31 +2,30 @@
 	loc_connections = list(
 		COMSIG_ATOM_ABSTRACT_ENTERED = PROC_REF(on_entered),
 		COMSIG_ATOM_ABSTRACT_EXITED = PROC_REF(on_uncrossed),
-		COMSIG_ATOM_INITIALIZED_ON = PROC_REF(on_entered),
+		COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON = PROC_REF(on_initialized),
 	)
-	var/list/mobs_in_range = list()
+	var/list/mobs_in_field = list()
 
 /datum/proximity_monitor/advanced/player_collector/New(atom/host, range, ignore_if_not_on_turf)
 	. = ..()
 	for(var/mob/user in range(range, host))
-		if(user.client)
-			mobs_in_range += user
-			SEND_SIGNAL(host, COMSIG_PROXIMITY_MOB_ENTERED, user)
-			RegisterSignal(user, COMSIG_QDELETING, PROC_REF(on_qdeleting))
+		mobs_in_field += user
+		SEND_SIGNAL(host, COMSIG_PROXIMITY_MOB_ENTERED, user)
+		RegisterSignal(user, COMSIG_QDELETING, PROC_REF(on_qdeleting))
 
 /datum/proximity_monitor/advanced/player_collector/Destroy()
-	for(var/mob/user in mobs_in_range)
+	for(var/mob/user in mobs_in_field)
 		UnregisterSignal(user, COMSIG_QDELETING)
-	qdel(mobs_in_range)
+	qdel(mobs_in_field)
 	return ..()
 
 /datum/proximity_monitor/advanced/player_collector/on_uncrossed(turf/source, atom/movable/gone, direction)
 	. = ..()
 	if(ismob(gone))
 		var/mob/user = gone
-		if(mobs_in_range.Find(user))
+		if(mobs_in_field.Find(user))
 			if(get_dist(gone, host) >= current_range || gone.z != host.z)
-				mobs_in_range -= user
+				mobs_in_field -= user
 				SEND_SIGNAL(host, COMSIG_PROXIMITY_MOB_LEFT, user)
 				UnregisterSignal(user, COMSIG_QDELETING)
 			else
@@ -36,34 +35,37 @@
 	. = ..()
 	if(ismob(entered))
 		var/mob/user = entered
-		if(user.client && !mobs_in_range.Find(user) && get_dist(user, host) < current_range)
-			mobs_in_range += user
+		if(!mobs_in_field.Find(user) && get_dist(user, host) < current_range)
+			mobs_in_field += user
 			SEND_SIGNAL(host, COMSIG_PROXIMITY_MOB_ENTERED, user)
 			RegisterSignal(user, COMSIG_QDELETING, PROC_REF(on_qdeleting))
 
 /datum/proximity_monitor/advanced/player_collector/on_moved(atom/movable/movable, atom/old_loc)
 	. = ..()
 	if(movable == host)
-		var/list/old_list = mobs_in_range.Copy()
-		mobs_in_range.Cut()
+		var/list/old_list = mobs_in_field.Copy()
+		mobs_in_field.Cut()
 		for(var/mob/user in range(current_range, host))
 			if(old_list.Find(user))
-				mobs_in_range += user
+				mobs_in_field += user
 				SEND_SIGNAL(host, COMSIG_PROXIMITY_MOB_MOVED, user)
 			else
-				if(user.client)
-					mobs_in_range += user
-					SEND_SIGNAL(host, COMSIG_PROXIMITY_MOB_ENTERED, user)
-					RegisterSignal(user, COMSIG_QDELETING, PROC_REF(on_qdeleting))
+				mobs_in_field += user
+				SEND_SIGNAL(host, COMSIG_PROXIMITY_MOB_ENTERED, user)
+				RegisterSignal(user, COMSIG_QDELETING, PROC_REF(on_qdeleting))
 		for(var/mob/user in old_list)
-			if(!mobs_in_range.Find(user))
+			if(!mobs_in_field.Find(user))
 				SEND_SIGNAL(host, COMSIG_PROXIMITY_MOB_LEFT, user)
 				UnregisterSignal(user, COMSIG_QDELETING)
 		qdel(old_list)
 
 /datum/proximity_monitor/advanced/player_collector/proc/on_qdeleting(mob/user)
 	if(ismob(user))
-		if(mobs_in_range.Find(user))
-			mobs_in_range -= user
+		if(mobs_in_field.Find(user))
+			mobs_in_field -= user
 			SEND_SIGNAL(host, COMSIG_PROXIMITY_MOB_LEFT, user)
 			UnregisterSignal(user, COMSIG_QDELETING)
+
+/datum/proximity_monitor/advanced/player_collector/proc/on_initialized(turf/source, atom/movable/entered)
+	if(ismob(entered))
+		addtimer(CALLBACK(src, PROC_REF(on_entered), source, entered), 1)

--- a/code/game/machinery/electrical_jukebox.dm
+++ b/code/game/machinery/electrical_jukebox.dm
@@ -93,7 +93,6 @@ GLOBAL_LIST_EMPTY_TYPED(jukebox_ban, /client)
 	var/list/queue = list()
 	var/list/requests = list()
 	var/list/listeners_in_range = list()
-	// var/list/clients_in_range = list()
 	var/datum/web_track/current_track
 	var/datum/proximity_monitor/advanced/player_collector/proximity_monitor
 	var/static/regex/ytdl_regex = regex(YTDL_REGEX, "s")
@@ -117,7 +116,7 @@ GLOBAL_LIST_EMPTY_TYPED(jukebox_ban, /client)
 		var/obj/structure/closet/supplypod/pod = loc
 		sleep(pod.delays[POD_TRANSIT] + pod.delays[POD_FALLING] + pod.delays[POD_OPENING] + 1)
 
-	proximity_monitor = new(src, range)
+	proximity_monitor = new(src, range, FALSE)
 	proximity_monitor.recalculate_field()
 
 /obj/machinery/electrical_jukebox/proc/cleanup()
@@ -132,9 +131,6 @@ GLOBAL_LIST_EMPTY_TYPED(jukebox_ban, /client)
 		for(var/mob/user in listeners_in_range)
 			user.client?.tgui_panel?.destroy_jukebox_player(id)
 
-		// for(var/client/client in clients_in_range)
-		// 	client.tgui_panel?.destroy_jukebox_player(id)
-
 		QDEL_NULL(proximity_monitor)
 
 		UnregisterSignal(src, COMSIG_PROXIMITY_MOB_ENTERED)
@@ -144,7 +140,6 @@ GLOBAL_LIST_EMPTY_TYPED(jukebox_ban, /client)
 	QDEL_NULL(queue)
 	QDEL_NULL(requests)
 	QDEL_NULL(listeners_in_range)
-	// QDEL_NULL(clients_in_range)
 
 	UnregisterSignal(src, COMSIG_QDELETING)
 
@@ -474,17 +469,11 @@ GLOBAL_LIST_EMPTY_TYPED(jukebox_ban, /client)
 		if(user.client && user.client.prefs.read_preference(/datum/preference/toggle/sound_jukebox))
 			to_chat(user, "[icon2html(src, user.client)] [span_boldnotice("Playing [track.webpage_url_html] added by [track.mob_name] on [src].")]")
 			user.client.tgui_panel?.play_jukebox_music(id, track.url, track.as_list, get_volume(user))
-	// for(var/client/client in clients_in_range)
-	// 	if(client.prefs.read_preference(/datum/preference/toggle/sound_jukebox))
-	// 		to_chat(client, "[icon2html(src, client)] [span_boldnotice("Playing [track.webpage_url_html] added by [track.mob_name] on [src].")]")
-	// 		client.tgui_panel?.play_jukebox_music(id, track.url, track.as_list, get_volume(client.mob))
 
 /obj/machinery/electrical_jukebox/proc/stop_in_mob_list()
 	for(var/mob/user in listeners_in_range)
 		if(user.client)
 			user.client.tgui_panel?.stop_jukebox_music(id)
-	// for(var/client/client in clients_in_range)
-	// 	client.tgui_panel?.stop_jukebox_music(id)
 
 /obj/machinery/electrical_jukebox/proc/play_music_by_track(datum/web_track/track, looped = FALSE)
 	if(busy || is_playing() || !anchored || !is_operational)
@@ -595,29 +584,33 @@ GLOBAL_LIST_EMPTY_TYPED(jukebox_ban, /client)
 	SIGNAL_HANDLER
 	if(is_playing() && listeners_in_range.Find(user))
 		user.client?.tgui_panel?.set_jukebox_volume(id, get_volume(user))
-	// if(is_playing() && clients_in_range.Find(user.client))
-	// 	user.client.tgui_panel?.set_jukebox_volume(id, get_volume(user))
 
 /obj/machinery/electrical_jukebox/proc/on_mob_entered(datum/source, mob/user)
 	SIGNAL_HANDLER
 	if(user.client?.prefs.read_preference(/datum/preference/toggle/sound_jukebox))
-	// if(!clients_in_range.Find(user.client) && user.client?.prefs.read_preference(/datum/preference/toggle/sound_jukebox))
-		listeners_in_range += user
-		// clients_in_range += user.client
+		if(!listeners_in_range.Find(user))
+			listeners_in_range += user
 		if(is_playing())
-			current_track.as_list["start"] = (world.time - track_started_at) / 10
-			user.client.tgui_panel?.play_jukebox_music(id, current_track.url, current_track.as_list, get_volume(user))
-		else
-			user.client.tgui_panel?.create_jukebox_player(id)
+			var/list/options = current_track.as_list.Copy()
+			options["start"] = (world.time - track_started_at) / 10
+			user.client.tgui_panel?.play_jukebox_music(id, current_track.url, options, get_volume(user))
+	RegisterSignal(user, COMSIG_MOB_CLIENT_LOGIN, PROC_REF(on_mob_login))
 
 /obj/machinery/electrical_jukebox/proc/on_mob_left(datum/source, mob/user)
 	SIGNAL_HANDLER
 	if(listeners_in_range.Find(user))
 		listeners_in_range -= user
 		user.client?.tgui_panel?.destroy_jukebox_player(id)
-	// if(clients_in_range.Find(user.client))
-	// 	clients_in_range -= user.client
-	// 	user.client?.tgui_panel?.destroy_jukebox_player(id)
+	UnregisterSignal(user, COMSIG_MOB_CLIENT_LOGIN)
+
+/obj/machinery/electrical_jukebox/proc/on_mob_login(mob/_mob, client/_client)
+	if(_client?.prefs.read_preference(/datum/preference/toggle/sound_jukebox))
+		if(!listeners_in_range.Find(_mob))
+			listeners_in_range += _mob
+		if(is_playing())
+			var/list/options = current_track.as_list.Copy()
+			options["start"] = (world.time - track_started_at) / 10
+			_client.tgui_panel?.play_jukebox_music(id, current_track.url, options, get_volume(_mob))
 
 /obj/item/electrical_jukebox_beacon
 	name = "electrical jukebox beacon"

--- a/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
+++ b/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
@@ -132,8 +132,20 @@ export const NowPlayingWidget = (props, context) => {
                       </Flex.Item>
                       <Flex.Item mx={0.5} fontSize="0.9em">
                         <Button
+                          tooltip="Stop"
+                          icon="stop"
+                          onClick={() =>
+                            dispatch({
+                              type: 'audio/jukebox/stopMusic',
+                              payload: { jukeboxId },
+                            })
+                          }
+                        />
+                      </Flex.Item>
+                      <Flex.Item mx={0.5} fontSize="0.9em">
+                        <Button
                           tooltip={muted ? 'Unmute' : 'Mute'}
-                          icon={muted ? 'play' : 'stop'}
+                          icon={muted ? 'volume-off' : 'volume-up'}
                           onClick={() =>
                             dispatch({
                               type: 'audio/jukebox/toggleMute',

--- a/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
+++ b/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
@@ -93,7 +93,8 @@ export const NowPlayingWidget = (props, context) => {
               url = audio.jukebox[jukeboxId]?.link,
               artist = audio.jukebox[jukeboxId]?.artist,
               album = audio.jukebox[jukeboxId]?.album,
-              duration = audio.jukebox[jukeboxId]?.duration;
+              duration = audio.jukebox[jukeboxId]?.duration,
+              muted = audio.muted.includes(jukeboxId);
 
             return (
               <Flex.Item key={jukeboxId}>
@@ -131,11 +132,11 @@ export const NowPlayingWidget = (props, context) => {
                       </Flex.Item>
                       <Flex.Item mx={0.5} fontSize="0.9em">
                         <Button
-                          tooltip="Stop"
-                          icon="stop"
+                          tooltip={muted ? 'Unmute' : 'Mute'}
+                          icon={muted ? 'play' : 'stop'}
                           onClick={() =>
                             dispatch({
-                              type: 'audio/jukebox/stopMusic',
+                              type: 'audio/jukebox/toggleMute',
                               payload: { jukeboxId },
                             })
                           }

--- a/tgui/packages/tgui-panel/audio/middleware.js
+++ b/tgui/packages/tgui-panel/audio/middleware.js
@@ -95,6 +95,10 @@ export const audioMiddleware = (store) => {
       }
       return next(action);
     }
+    if (type === 'audio/jukebox/toggleMute') {
+      // jukeboxPlayers[payload.jukeboxId]?.toggleMute();
+      return next(action);
+    }
     return next(action);
   };
 };

--- a/tgui/packages/tgui-panel/audio/middleware.js
+++ b/tgui/packages/tgui-panel/audio/middleware.js
@@ -5,6 +5,7 @@
  */
 
 import { AudioPlayer } from './player';
+import { selectAudio } from './selectors';
 
 export const audioMiddleware = (store) => {
   const player = new AudioPlayer();
@@ -40,8 +41,10 @@ export const audioMiddleware = (store) => {
     }
     if (type === 'audio/jukebox/create') {
       if (!jukeboxPlayers[payload.jukeboxId]) {
+        const audio = selectAudio(store.getState());
         const player = new AudioPlayer();
         jukeboxPlayers[payload.jukeboxId] = player;
+        player.muted = audio.muted.includes(payload.jukeboxId);
         player.setVolume(adminMusicVolume);
         player.onPlay(() => store.dispatch({ type: 'audio/jukebox/playing' }));
         player.onStop(() =>
@@ -70,8 +73,10 @@ export const audioMiddleware = (store) => {
       if (jukeboxPlayers[jukeboxId]) {
         jukeboxPlayers[jukeboxId].play(url, options, volume);
       } else {
+        const audio = selectAudio(store.getState());
         const player = new AudioPlayer();
         jukeboxPlayers[jukeboxId] = player;
+        player.muted = audio.muted.includes(payload.jukeboxId);
         player.setVolume(adminMusicVolume);
         player.onPlay(() => store.dispatch({ type: 'audio/jukebox/playing' }));
         player.onStop(() =>
@@ -96,7 +101,7 @@ export const audioMiddleware = (store) => {
       return next(action);
     }
     if (type === 'audio/jukebox/toggleMute') {
-      // jukeboxPlayers[payload.jukeboxId]?.toggleMute();
+      jukeboxPlayers[payload.jukeboxId]?.toggleMute();
       return next(action);
     }
     return next(action);

--- a/tgui/packages/tgui-panel/audio/player.js
+++ b/tgui/packages/tgui-panel/audio/player.js
@@ -20,6 +20,7 @@ export class AudioPlayer {
     document.body.appendChild(this.node);
     // Set up other properties
     this.playing = false;
+    this.muted = false;
     this.volume = 1;
     this.localVolume = 1;
     this.options = {};
@@ -32,7 +33,7 @@ export class AudioPlayer {
         this.playing = true;
         this.node.playbackRate = this.options.pitch || 1;
         this.node.currentTime = this.options.start || 0;
-        this.node.volume = this.volume * this.localVolume;
+        this.node.volume = this.muted ? 0 : this.volume * this.localVolume;
         this.node.play();
         for (let subscriber of this.onPlaySubscribers) {
           subscriber();
@@ -99,14 +100,21 @@ export class AudioPlayer {
   setVolume(volume) {
     if (this.node) {
       this.volume = volume;
-      this.node.volume = this.localVolume * volume;
+      if (!this.muted) this.node.volume = this.localVolume * volume;
     }
   }
 
   setLocalVolume(volume) {
     if (this.node) {
       this.localVolume = volume;
-      this.node.volume = this.volume * volume;
+      if (!this.muted) this.node.volume = this.volume * volume;
+    }
+  }
+
+  toggleMute() {
+    if (this.node) {
+      this.muted = !this.muted;
+      this.node.volume = this.muted ? 0 : this.volume * this.localVolume;
     }
   }
 

--- a/tgui/packages/tgui-panel/audio/player.js
+++ b/tgui/packages/tgui-panel/audio/player.js
@@ -26,8 +26,8 @@ export class AudioPlayer {
     this.onPlaySubscribers = [];
     this.onStopSubscribers = [];
     // Listen for playback start events
-    this.playthroughListener = () => {
-      if (this.node && this.node.playbackRate) {
+    this.node.addEventListener('canplaythrough', () => {
+      if (this.node && this.node instanceof HTMLAudioElement) {
         logger.log('canplaythrough');
         this.playing = true;
         this.node.playbackRate = this.options.pitch || 1;
@@ -38,8 +38,7 @@ export class AudioPlayer {
           subscriber();
         }
       }
-    };
-    this.node.addEventListener('canplaythrough', this.playthroughListener);
+    });
     // Listen for playback stop events
     this.node.addEventListener('ended', () => {
       logger.log('ended');
@@ -66,23 +65,14 @@ export class AudioPlayer {
   }
 
   destroy() {
-    for (const subscriber of this.onStopSubscribers) {
-      subscriber();
-    }
-    logger.log('stopping');
-    clearInterval(this.playbackInterval);
-    this.playing = false;
     if (this.node) {
-      this.node.src = '';
-      this.node.stop?.();
-      this.node.removeEventListener?.(
-        'canplaythrough',
-        this.playthroughListener
-      );
+      this.stop();
+      logger.log('destroyed');
+      clearInterval(this.playbackInterval);
       try {
         document.body.removeChild(this.node);
       } catch {}
-      delete this.node;
+      this.node = null;
     }
   }
 

--- a/tgui/packages/tgui-panel/audio/reducer.js
+++ b/tgui/packages/tgui-panel/audio/reducer.js
@@ -9,13 +9,14 @@ const initialState = {
   playing: false,
   track: null,
   jukebox: {},
+  muted: [],
 };
 
 const visible = (state, payload) => {
   let visible = !!state.meta;
   if (!visible) {
     for (const key of Object.keys(state.jukebox)) {
-      if (key === payload.jukeboxId) continue;
+      if (payload && key === payload.jukeboxId) continue;
       if (state.jukebox[key]) {
         visible = true;
         break;
@@ -35,11 +36,9 @@ export const audioReducer = (state = initialState, action) => {
     };
   }
   if (type === 'audio/stopped') {
-    const visible = Object.values(state.jukebox).filter((s) => !!s).length > 0;
-
     return {
       ...state,
-      visible,
+      visible: visible(state),
       playing: false,
     };
   }
@@ -52,7 +51,7 @@ export const audioReducer = (state = initialState, action) => {
   if (type === 'audio/stopMusic') {
     return {
       ...state,
-      visible: false,
+      visible: visible(state),
       playing: false,
       meta: null,
     };
@@ -105,6 +104,20 @@ export const audioReducer = (state = initialState, action) => {
         ...state.jukebox,
         [payload.jukeboxId]: payload,
       },
+    };
+  }
+  if (type === 'audio/jukebox/toggleMute') {
+    const muted = state.muted;
+
+    if (muted.includes(payload.jukeboxId)) {
+      muted.splice(muted.indexOf(payload.jukebox), 1);
+    } else {
+      muted.push(payload.jukeboxId);
+    }
+
+    return {
+      ...state,
+      muted,
     };
   }
   return state;

--- a/tgui/packages/tgui/components/DraggableControl.js
+++ b/tgui/packages/tgui/components/DraggableControl.js
@@ -136,13 +136,15 @@ export class DraggableControl extends Component {
         }
       } else if (this.inputRef) {
         const input = this.inputRef.current;
-        input.value = internalValue;
-        // IE8: Dies when trying to focus a hidden element
-        // (Error: Object does not support this action)
-        try {
-          input.focus();
-          input.select();
-        } catch {}
+        if (input) {
+          input.value = internalValue;
+          // IE8: Dies when trying to focus a hidden element
+          // (Error: Object does not support this action)
+          try {
+            input.focus();
+            input.select();
+          } catch {}
+        }
       }
     };
   }

--- a/tgui/packages/tgui/components/NumberInput.js
+++ b/tgui/packages/tgui/components/NumberInput.js
@@ -126,13 +126,15 @@ export class NumberInput extends Component {
         }
       } else if (this.inputRef) {
         const input = this.inputRef.current;
-        input.value = internalValue;
-        // IE8: Dies when trying to focus a hidden element
-        // (Error: Object does not support this action)
-        try {
-          input.focus();
-          input.select();
-        } catch {}
+        if (input) {
+          input.value = internalValue;
+          // IE8: Dies when trying to focus a hidden element
+          // (Error: Object does not support this action)
+          try {
+            input.focus();
+            input.select();
+          } catch {}
+        }
       }
     };
   }


### PR DESCRIPTION
## About The Pull Request

Jukebox playerına mute butonu ekler ve ayrıca farkında olduğum birkaç hatayı çözer.

## Why It's Good For The Game

Jukebox'ın sesini stop butonu ile kapattığınızda geri açmak isterseniz alandan çıkıp girmeniz geri girmeniz gerekiyordu bu saçma gereksinimi önlemek amacıyla mute butonu ekledim.

## Changelog

:cl:
add: Jukebox playerına mute butonu eklendi.
fix: Jukebox alanında sonradan girmeyip içerisinde doğanlar için ses çalacak.
fix: Jukebox alanındaki mobun clientı değiştiğinde yeni client için ses çalacak.
/:cl:

![image](https://github.com/psychonaut-station/PsychonautStation/assets/50076109/cca76e2e-00d7-4b43-a734-65ecf1a30860)
![image](https://github.com/psychonaut-station/PsychonautStation/assets/50076109/e4aaa919-313c-43b6-8fa6-e3d29704935a)
