### PR TITLE
anomaly core suicide bug fix

### DIFF
--- a/code/modules/research/anomaly/anomaly_core.dm
+++ b/code/modules/research/anomaly/anomaly_core.dm
@@ -20,7 +20,8 @@
 		A.anomalyNeutralize()
 	return TRUE
 
-/obj/item/assembly/signaler/anomaly/manual_suicide(mob/living/carbon/user)
+/obj/item/assembly/signaler/anomaly/manual_suicide(datum/mind/suicidee)
+	var/mob/living/user = suicidee.current
 	user.visible_message(span_suicide("[user]'s [src] is reacting to the radio signal, warping [user.p_their()] body!"))
 	user.set_suicide(TRUE)
 	user.gib()


### PR DESCRIPTION
## Pull Request Hakkında
Anomaly core ile intihar ettikten sonra sinyal yollandığında oyuncu ölmüyor koddaki hata düzeltildi

## Oyun için neden gerekli
bug fix

## Changelog

:cl:
fix: anomaly core ile intihar ederken sinyal yollandıktan sonra ölmeme sorunu çözüldü.
/:cl:
