### PR TITLE
Küçük I

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -185,7 +185,7 @@
 			// a  .. z
 			if(97 to 122) //Lowercase Letters
 				if(last_char_group == NO_CHARS_DETECTED || last_char_group == SPACES_DETECTED || cap_after_symbols && last_char_group == SYMBOLS_DETECTED) //start of a word
-					char = uppertext(char)
+					char = locale_uppertext(char)
 				number_of_alphanumeric++
 				last_char_group = LETTERS_DETECTED
 
@@ -354,12 +354,20 @@
 	. = t
 	if(t)
 		. = t[1]
-		return uppertext(.) + copytext(t, 1 + length(.))
+		return locale_uppertext(.) + copytext(t, 1 + length(.))
 
 ///Returns a string with the first letter of each word capitialized
 /proc/full_capitalize(input)
 	var/regex/first_letter = new(@"[^A-z]*?([A-z]*)", "g")
 	return replacetext(input, first_letter, /proc/capitalize)
+
+/proc/locale_uppertext(t)
+	. = ""
+	for(var/c in text2charlist(t))
+		if(c == "\u0131") // ı
+			. += "\u0049" // I
+		else
+			. += uppertext(c)
 
 /proc/stringmerge(text,compare,replace = "*")
 //This proc fills in all spaces with the "replace" var (* by default) with whatever

--- a/code/datums/status_effects/debuffs/speech_debuffs.dm
+++ b/code/datums/status_effects/debuffs/speech_debuffs.dm
@@ -108,7 +108,7 @@
 
 	if(prob(capitalize_prob))
 		var/exclamation = pick("!", "!!", "!!!")
-		message = uppertext(message)
+		message = locale_uppertext(message)
 		message += "[apply_speech(exclamation, exclamation)]"
 
 	message_args[TREAT_MESSAGE_ARG] = message

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
  * and the return value of this proc the cooldown variable of the command dictates. (only relevant for things with cooldowns i guess)
  */
 /proc/voice_of_god(message, mob/living/user, list/span_list, base_multiplier = 1, include_speaker = FALSE, forced = null, ignore_spam = FALSE)
-	var/log_message = uppertext(message)
+	var/log_message = locale_uppertext(message)
 	var/is_cultie = IS_CULTIST(user)
 	if(LAZYLEN(span_list) && is_cultie)
 		span_list = list("narsiesmall")

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -92,8 +92,8 @@
 
 /// Immediately change the display to the given two lines.
 /obj/machinery/status_display/proc/set_messages(line1, line2)
-	line1 = uppertext(line1)
-	line2 = uppertext(line2)
+	line1 = locale_uppertext(line1)
+	line2 = locale_uppertext(line2)
 
 	var/message_changed = FALSE
 	if(line1 != message1)

--- a/code/game/objects/effects/wanted_poster.dm
+++ b/code/game/objects/effects/wanted_poster.dm
@@ -85,7 +85,7 @@
 	var/startX = 16 - (2*textLen)
 	var/i
 	for(i=1; i <= textLen, i++)
-		var/letter = uppertext(text[i])
+		var/letter = locale_uppertext(text[i])
 		var/icon/letter_icon = icon("icon" = 'icons/misc/Font_Minimal.dmi', "icon_state" = letter)
 		letter_icon.Shift(EAST, startX) //16 - (2*n)
 		letter_icon.Shift(SOUTH, 2)

--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -40,7 +40,7 @@
 		message = replacetext(message, "library", "biblioteca")
 		message = replacetext(message, "traitor", "traidor")
 		message = replacetext(message, "wizard", "mago")
-		message = uppertext(message) //Things end up looking better this way (no mixed cases), and it fits the macho wrestler image.
+		message = locale_uppertext(message) //Things end up looking better this way (no mixed cases), and it fits the macho wrestler image.
 		if(prob(25))
 			message += " OLE!"
 	speech_args[SPEECH_MESSAGE] = message

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -189,7 +189,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		// Make sure the arglist is passed exactly - don't pass a copy of it. Say signal handlers will modify some of the parameters.
 		var/sigreturn = SEND_SIGNAL(src, COMSIG_MOB_SAY, args)
 		if(sigreturn & COMPONENT_UPPERCASE_SPEECH)
-			message = uppertext(message)
+			message = locale_uppertext(message)
 
 	var/list/message_data = treat_message(message) // unfortunately we still need this
 	message = message_data["message"]

--- a/code/modules/spells/spell_types/self/voice_of_god.dm
+++ b/code/modules/spells/spell_types/self/voice_of_god.dm
@@ -34,7 +34,7 @@
 
 /datum/action/cooldown/spell/voice_of_god/cast(atom/cast_on)
 	. = ..()
-	var/command_cooldown = voice_of_god(uppertext(command), cast_on, spans, base_multiplier = power_mod)
+	var/command_cooldown = voice_of_god(locale_uppertext(command), cast_on, spans, base_multiplier = power_mod)
 	cooldown_time = (command_cooldown * cooldown_mod)
 
 // "Invocation" is done by the actual voice of god proc

--- a/code/modules/surgery/organs/internal/vocal_cords/_vocal_cords.dm
+++ b/code/modules/surgery/organs/internal/vocal_cords/_vocal_cords.dm
@@ -83,7 +83,7 @@
 	return //voice of god speaks for us
 
 /obj/item/organ/internal/vocal_cords/colossus/speak_with(message)
-	var/cooldown = voice_of_god(uppertext(message), owner, spans, base_multiplier)
+	var/cooldown = voice_of_god(locale_uppertext(message), owner, spans, base_multiplier)
 	next_command = world.time + (cooldown * cooldown_mod)
 
 /obj/item/organ/internal/adamantine_resonator

--- a/code/modules/wiremod/components/string/textcase.dm
+++ b/code/modules/wiremod/components/string/textcase.dm
@@ -43,7 +43,7 @@
 		if(COMP_TEXT_LOWER)
 			result = lowertext(value)
 		if(COMP_TEXT_UPPER)
-			result = uppertext(value)
+			result = locale_uppertext(value)
 
 	output.set_output(result)
 


### PR DESCRIPTION
## Pull Request Hakkında

Byondda küçük "ı" harfi sorun yarattığından dolayı özellikle konuşurken "ı" harfini uppertext yapınca (konuşurken ilk harf büyük çıkıyor) cümledeki tüm türkçe karakterler bozuluyordu ve cümle anlaşılmaz hale geliyor. Bu PR'da bu soruna geçici çözüm getiriyor. Olması gereken tabi ki bu değil olması gereken sorunun byond ile çözmesi fakat geçici olarak bu çözümü kullanabiliriz.

"ç", "ğ", "ö", "ş", "ü" harfleri buna sebep olmuyor yalnızca "ı".

## Oyun için neden gerekli

"ı" ile başlayan cümleler anlaşılmayacak şekilde bozuluyor.

## Changelog

:cl:
fix: Artık cümleye "ı" ile başlandığında cümle bozulmayacak.
/:cl:

![image](https://github.com/psychonaut-station/PsychonautStation/assets/50076109/103329a7-ed71-47ef-85f8-45a153032cf7)
