### PR TITLE
tgmc ruin düzenleme

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/tgmc_ruin.dmm
+++ b/_maps/RandomRuins/SpaceRuins/tgmc_ruin.dmm
@@ -178,10 +178,6 @@
 /turf/open/space/basic,
 /area/ruin/space)
 "pN" = (
-/obj/effect/mob_spawn/corpse/human/commander{
-	mob_name = "Husnu Tgmcogullari";
-	outfit = /datum/outfit/centcom/ert/marine
-	},
 /turf/open/floor/iron/tgmcemblem{
 	dir = 5
 	},


### PR DESCRIPTION
## Pull Request Hakkında

tgmc ruininden centcom id'yi kaldırdım.

## Oyun için neden gerekli

denge

## Changelog

:cl:
del: TGMC ruininde centcom id olmayacak.
/:cl:
