### PR TITLE
ministation sm odası fix

### DIFF
--- a/_maps/map_files/MiniStation/MiniStation.dmm
+++ b/_maps/map_files/MiniStation/MiniStation.dmm
@@ -8441,7 +8441,6 @@
 /area/station/engineering/main)
 "uU" = (
 /obj/structure/cable,
-/obj/machinery/power/emitter/welded,
 /obj/machinery/power/emitter/welded{
 	dir = 8
 	},


### PR DESCRIPTION
## Pull Request Hakkında
ministation sm odası fixi
## Oyun için neden gerekli
sm odasında 2 emitter üst üste binmiş düzeltmek için
## Changelog

:cl:
fix: MiniStation haritasindaki sm odasi düzeltildi
/:cl:
