### PR TITLE
eski deltadaki bar sandalyelerinin yönünü düzeltir

### DIFF
--- a/_maps/map_files/Deltastation/AncientDeltaStation.dmm
+++ b/_maps/map_files/Deltastation/AncientDeltaStation.dmm
@@ -9116,10 +9116,10 @@
 /area/station/maintenance/port/aft)
 "bBg" = (
 /obj/effect/landmark/start/assistant,
-/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "bBi" = (
@@ -37218,10 +37218,10 @@
 /area/station/maintenance/starboard/fore)
 "gbz" = (
 /obj/effect/landmark/start/hangover,
-/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "gbB" = (
@@ -49602,10 +49602,10 @@
 /turf/open/floor/iron,
 /area/station/service/lawoffice)
 "jOV" = (
-/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "jOW" = (
@@ -78734,11 +78734,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "stu" = (
-/obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "stP" = (


### PR DESCRIPTION
## Pull Request Hakkında

eski deltadaki bar sandalyelerinin yönünü düzeltir

## Oyun için neden gerekli

bar sandalyeleri ters olduğundan turist robotları düzgün çalışmıyordu

## Changelog

:cl:
fix: Eski deltadaki bar sandalyeleri doğru yöne bakacak.
/:cl:
