### PR TITLE
Jukebox Takılı Kalma

### DIFF
--- a/code/datums/components/web_sound_player.dm
+++ b/code/datums/components/web_sound_player.dm
@@ -126,7 +126,7 @@ GLOBAL_VAR_INIT(youtubedl_regex, regex(@"^(https?:\/\/)?(www\.)?(youtube\.com\/|
 			for(var/mob/living/listener in listeners)
 				listener.apply_status_effect(status_effect)
 
-	if(track && world.time - track_started_at > track.duration)
+	if(track && world.time - track_started_at >= track.duration)
 		stop()
 		SEND_SIGNAL(src, COMSIG_WEB_SOUND_ENDED, track, loop)
 		if(loop)


### PR DESCRIPTION
## Pull Request Hakkında

jukebox bazenleri şarkı bitmesine rağmen takılı kalıyordu
böyle yaptığımda düzeleceğini umuyorum
test etmedim çünkü sürekli olan bir şey de değil

## Oyun için neden gerekli

bug fix

## Changelog

:cl:
fix: Jukebox şarkı bittiğinde takılı kalmayacak.
/:cl:
