### PR TITLE
Isik efektlerini patlamalardan kaldiriyor

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -558,8 +558,6 @@ SUBSYSTEM_DEF(explosions)
 		if(creaking) // 5 seconds after the bang, the station begins to creak
 			addtimer(CALLBACK(listener, TYPE_PROC_REF(/mob, playsound_local), epicenter, null, rand(FREQ_LOWER, FREQ_UPPER), TRUE, frequency, null, null, FALSE, hull_creaking_sound, 0), CREAK_DELAY)
 
-	if (creaking)
-		creak_lights()
 
 #undef CREAK_DELAY
 #undef QUAKE_CREAK_PROB

--- a/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
@@ -87,6 +87,9 @@
 		adminlog = TRUE,
 		ignorecap = TRUE
 	)
+
+	creak_lights()
+	
 	return TRUE
 
 /// Spawns a scrung and eat the SM.


### PR DESCRIPTION
## Oyun için neden gerekli
devast range >1 oldugunda butun istasyonun isiklarinin kapalip acilmasi sinir bozucu, patlamalardan kaldirip sm'ye ekeldim
## Changelog

:cl:
del: ışıklar artık patlamalardan yanıp sönmeyecek (sm ve grav gen dahil değil)
/:cl:
