### PR TITLE
(Eski Delta) Surgery tray artık itemli şekilde spawnlanıyor

### DIFF
--- a/_maps/map_files/Deltastation/AncientDeltaStation.dmm
+++ b/_maps/map_files/Deltastation/AncientDeltaStation.dmm
@@ -90468,7 +90468,7 @@
 /area/station/hallway/primary/central/aft)
 "vTm" = (
 /obj/structure/table/reinforced,
-/obj/item/surgery_tray,
+/obj/item/surgery_tray/full,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},


### PR DESCRIPTION
## Pull Request Hakkında
Eski delta mapi üzerindeki sorunu gidererek surgery trayin eşyalı olarak spawnlanmasını sağlıyor.
## Oyun için neden gerekli
Coroner artık eşyalarını oyun başı elde edebilecek.
## Changelog

:cl: genku
fix: Eski Delta'daki surgery tray dolu başlayacak
/:cl:
