### PR TITLE
Fix - Brig Physician latejoin icon

### DIFF
--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -9,7 +9,7 @@ export const JOB2ICON = {
   'Bit Avatar': 'code',
   Bitrunner: 'gamepad',
   Botanist: 'seedling',
-  'Brig Physician': 'shield-plus',
+  'Brig Physician': 'shield-heart',
   Captain: 'crown',
   'Cargo Gorilla': 'paw',
   'Cargo Technician': 'box',


### PR DESCRIPTION
## Pull Request Hakkında
Brig Physicianın iconu font awasomede proya alındıgı icin gozukmuyordu.
![image](https://github.com/psychonaut-station/PsychonautStation/assets/60517664/4f899225-efbc-4107-bbcf-2c9903d6398a)

Yeni hali bu
![image](https://github.com/psychonaut-station/PsychonautStation/assets/60517664/2b7694ab-534b-4d1a-82a8-1151d9a45acf)

## Changelog

:cl:
fix: Latejoin Brig Physician iconu düzeltildi.
/:cl:
