### PR TITLE
Eski Delta Huge Air

### DIFF
--- a/_maps/map_files/Deltastation/AncientDeltaStation.dmm
+++ b/_maps/map_files/Deltastation/AncientDeltaStation.dmm
@@ -35244,6 +35244,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "fxw" = (
@@ -39240,6 +39241,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
+"gJo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/project)
 "gJq" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/camera/directional/south{
@@ -73623,6 +73633,8 @@
 "qNT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/portable_atmospherics/scrubber/huge/movable,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "qOd" = (
@@ -92431,6 +92443,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"wwR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/project)
 "wwY" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -126163,8 +126184,8 @@ twf
 awb
 ovk
 ovk
-xpD
-xpD
+wwR
+gJo
 tyw
 kPH
 kPH


### PR DESCRIPTION

## Pull Request Hakkında

Eski Delta İçin Atmosa huge air scrubber ekler.

## Oyun İçin Neden Gerekli

Delta2 istasyonunda bulunuyor gerekli olabilir.

## Changelog

Eski Delta atmosa huge air scrubber ekler.

:cl:
add: Eski Delta Atmosa Huge Air Scrubber eklendi.
/:cl:
