### PR TITLE
Yeni Ruinler Projesi

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/gas_station.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gas_station.dmm
@@ -56,6 +56,7 @@
 	},
 /obj/machinery/light/very_dim/directional/north,
 /obj/structure/sign/clock/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
@@ -430,6 +431,7 @@
 	pixel_y = 25
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 8
 	},
@@ -557,6 +559,9 @@
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
@@ -638,6 +643,9 @@
 	dir = 10
 	},
 /obj/machinery/light/small/dim/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 4
 	},

--- a/_maps/RandomRuins/SpaceRuins/gas_station.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gas_station.dmm
@@ -1,0 +1,1285 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ae" = (
+/obj/machinery/power/shuttle_engine/propulsion{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/ruin/space/has_grav/gas_station)
+"aB" = (
+/obj/structure/sign/poster/contraband/syndicate_recruitment/directional/north,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/turf/open/floor/iron/dark/textured_edge,
+/area/ruin/space/has_grav/gas_station)
+"bq" = (
+/obj/structure/table/wood,
+/obj/machinery/fax,
+/turf/open/floor/iron/dark/textured,
+/area/ruin/space/has_grav/gas_station)
+"bH" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 8
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/ruin/space/has_grav/gas_station)
+"bZ" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/vending/cigarette,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"eE" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/railing/corner,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"gJ" = (
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/obj/machinery/light/very_dim/directional/north,
+/obj/structure/sign/clock/directional/north,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/ruin/space/has_grav/gas_station)
+"hm" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 10
+	},
+/obj/effect/spawner/random/food_or_drink/donuts,
+/obj/effect/spawner/random/food_or_drink/donuts,
+/obj/machinery/light/very_dim/directional/south,
+/obj/structure/sign/poster/contraband/lusty_xenomorph/directional/south,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/gas_station)
+"hz" = (
+/obj/structure/flora/rock/icy/style_2,
+/turf/open/misc/asteroid/moon,
+/area/ruin/space/has_grav/gas_station)
+"iZ" = (
+/obj/item/kirbyplants/random/dead,
+/turf/open/misc/asteroid/moon,
+/area/ruin/space/has_grav/gas_station)
+"jc" = (
+/obj/structure/flora/rock/icy/style_3,
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"jV" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"kp" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/green/corner,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 9
+	},
+/obj/effect/spawner/random/decoration,
+/obj/effect/spawner/random/decoration,
+/obj/structure/sign/poster/contraband/jumbo_bar/directional/north,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/dark/textured_corner,
+/area/ruin/space/has_grav/gas_station)
+"ks" = (
+/obj/effect/turf_decal/stripes/asteroid/box,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"lI" = (
+/turf/closed/mineral,
+/area/ruin/space/has_grav/gas_station)
+"mr" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 6
+	},
+/obj/effect/spawner/random/entertainment/plushie,
+/obj/effect/spawner/random/entertainment/plushie,
+/obj/effect/spawner/random/entertainment/plushie,
+/obj/structure/sign/poster/contraband/pizza_imperator/directional/east,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/gas_station)
+"nd" = (
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/obj/effect/spawner/random/entertainment/money_large,
+/turf/open/floor/iron/dark/textured_edge,
+/area/ruin/space/has_grav/gas_station)
+"nj" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/turf/open/floor/iron/dark/textured_edge,
+/area/ruin/space/has_grav/gas_station)
+"nm" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"nn" = (
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/has_grav/gas_station)
+"oa" = (
+/obj/structure/flora/rock/pile/icy/style_2,
+/turf/open/misc/asteroid/moon,
+/area/ruin/space/has_grav/gas_station)
+"oS" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/misc/asteroid/moon,
+/area/ruin/space/has_grav/gas_station)
+"pg" = (
+/obj/structure/reagent_dispensers/fueltank/large,
+/obj/structure/sign/poster/contraband/microwave/directional/north,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"pp" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/green/line,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/entertainment/musical_instrument,
+/obj/effect/spawner/random/entertainment/musical_instrument,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/ruin/space/has_grav/gas_station)
+"qg" = (
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/gas_station)
+"qh" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/food/popsicle/creamsicle_orange,
+/obj/item/food/popsicle/creamsicle_orange,
+/obj/item/food/popsicle/creamsicle_berry,
+/obj/item/food/popsicle/creamsicle_berry,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"qs" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/misc/asteroid/moon,
+/area/ruin/space/has_grav/gas_station)
+"qJ" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/misc/asteroid/moon,
+/area/ruin/space/has_grav/gas_station)
+"qU" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured,
+/area/ruin/space/has_grav/gas_station)
+"re" = (
+/obj/effect/turf_decal/stripes/asteroid/box,
+/obj/structure/marker_beacon/jade,
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"rp" = (
+/obj/structure/flora/rock/pile/icy/style_random,
+/obj/structure/railing,
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"sv" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/ruin/space/has_grav/gas_station)
+"ta" = (
+/obj/effect/spawner/random/entertainment/drugs,
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"tt" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"uj" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"uy" = (
+/obj/structure/sign/poster/contraband/smoke/directional/north,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/turf/open/floor/iron/dark/textured_edge,
+/area/ruin/space/has_grav/gas_station)
+"uL" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/railing,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"vg" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/iron/dark/textured,
+/area/ruin/space/has_grav/gas_station)
+"vk" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/asteroid/moon,
+/area/ruin/space/has_grav/gas_station)
+"vo" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"vv" = (
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 1
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured,
+/area/ruin/space/has_grav/gas_station)
+"vB" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron/dark/textured_edge,
+/area/ruin/space/has_grav/gas_station)
+"vD" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"vX" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"wa" = (
+/obj/machinery/bluespace_vendor/directional/south,
+/obj/effect/turf_decal/trimline/green/line,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/ruin/space/has_grav/gas_station)
+"wc" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ruin/space/has_grav/gas_station)
+"wI" = (
+/obj/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/gas_station)
+"xt" = (
+/obj/effect/turf_decal/stripes/asteroid/box,
+/obj/structure/marker_beacon/burgundy,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"xx" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/has_grav/gas_station)
+"xU" = (
+/obj/effect/spawner/random/entertainment/toy_figure,
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"yd" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/ruin/space/has_grav/gas_station)
+"yO" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"yQ" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_edge,
+/area/ruin/space/has_grav/gas_station)
+"zr" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/ruin/space/has_grav/gas_station)
+"zA" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 4
+	},
+/obj/machinery/light/small/dim/directional/north,
+/obj/machinery/airalarm{
+	pixel_y = 25
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/gas_station)
+"Cb" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"Cs" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/iron/dark/textured_edge,
+/area/ruin/space/has_grav/gas_station)
+"DO" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"DY" = (
+/obj/machinery/power/shuttle_engine/heater{
+	dir = 8
+	},
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"Ew" = (
+/obj/effect/turf_decal/stripes/asteroid/box,
+/obj/structure/marker_beacon/bronze,
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"EE" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/misc/asteroid/moon,
+/area/ruin/space/has_grav/gas_station)
+"Gu" = (
+/turf/open/misc/asteroid/moon,
+/area/ruin/space/has_grav/gas_station)
+"Gx" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/green/line,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/food_or_drink/booze,
+/obj/effect/spawner/random/food_or_drink/booze,
+/obj/effect/spawner/random/food_or_drink/booze,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/ruin/space/has_grav/gas_station)
+"He" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"Ig" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/stripes/asteroid/box,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"IG" = (
+/obj/structure/railing,
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"IJ" = (
+/obj/structure/flora/rock/pile/icy/style_2,
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"IM" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured,
+/area/ruin/space/has_grav/gas_station)
+"Jh" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 8
+	},
+/obj/structure/sign/clock/directional/north,
+/obj/item/kirbyplants/random/dead,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/dark/textured_corner,
+/area/ruin/space/has_grav/gas_station)
+"JI" = (
+/obj/structure/railing/corner,
+/turf/open/misc/asteroid/moon,
+/area/ruin/space/has_grav/gas_station)
+"JK" = (
+/obj/structure/sign/poster/contraband/pizza_imperator/directional/south,
+/obj/effect/turf_decal/trimline/green/line,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/ruin/space/has_grav/gas_station)
+"KQ" = (
+/obj/structure/flora/rock/icy/style_3,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/misc/asteroid/moon,
+/area/ruin/space/has_grav/gas_station)
+"Lt" = (
+/obj/effect/turf_decal/trimline/green/corner,
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/ruin/space/has_grav/gas_station)
+"LB" = (
+/obj/structure/flora/rock/pile/icy/style_3,
+/obj/structure/railing,
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"LJ" = (
+/obj/effect/turf_decal/stripes/asteroid/box,
+/obj/structure/marker_beacon/indigo,
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"Mc" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/vending/coffee,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"Mf" = (
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/gas_station)
+"Mx" = (
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 6
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/wrapping,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/gas_station)
+"MA" = (
+/obj/structure/sign/poster/contraband/masked_men/directional/east,
+/obj/machinery/power/shuttle_engine/heater{
+	dir = 8
+	},
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"MS" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/item/kirbyplants/random/dead,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"MU" = (
+/obj/structure/flora/rock/icy,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"Nd" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/food/popsicle/sea_salt,
+/obj/item/food/popsicle/sea_salt,
+/obj/item/food/popsicle/jumbo,
+/obj/item/food/popsicle/jumbo,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"NH" = (
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 10
+	},
+/obj/machinery/light/small/dim/directional/south,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/gas_station)
+"NZ" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/turf/open/floor/iron/dark/textured_edge,
+/area/ruin/space/has_grav/gas_station)
+"Oj" = (
+/obj/effect/spawner/random/entertainment/plushie,
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"OD" = (
+/obj/structure/railing,
+/turf/open/misc/asteroid/moon,
+/area/ruin/space/has_grav/gas_station)
+"Rb" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/dark/textured,
+/area/ruin/space/has_grav/gas_station)
+"RW" = (
+/obj/effect/spawner/random/exotic/tool,
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"Sk" = (
+/obj/effect/turf_decal/trimline/green/corner,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured_corner,
+/area/ruin/space/has_grav/gas_station)
+"Tp" = (
+/obj/effect/turf_decal/trimline/green/line,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/ruin/space/has_grav/gas_station)
+"Tq" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/spawner/random/entertainment/cigarette_pack{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/ruin/space/has_grav/gas_station)
+"TO" = (
+/turf/open/misc/asteroid,
+/area/ruin/space/has_grav/gas_station)
+"Uf" = (
+/obj/structure/sign/poster/contraband/communist_state/directional/south,
+/obj/effect/turf_decal/trimline/green/line,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/ruin/space/has_grav/gas_station)
+"Uy" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/misc/asteroid/moon,
+/area/ruin/space/has_grav/gas_station)
+"Vb" = (
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 5
+	},
+/obj/machinery/airalarm{
+	pixel_y = 25
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/gas_station)
+"Vn" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"VQ" = (
+/obj/effect/spawner/random/structure/billboard/nanotrasen,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/gas_station)
+"Wj" = (
+/obj/effect/turf_decal/trimline/green/line,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/contraband,
+/obj/effect/spawner/random/contraband,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/ruin/space/has_grav/gas_station)
+"Wl" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 5
+	},
+/obj/effect/spawner/random/entertainment/cigarette_pack{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/effect/spawner/random/entertainment/cigarette_pack{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/effect/spawner/random/entertainment/cigarette_pack,
+/obj/effect/spawner/random/entertainment/cigarette_pack,
+/obj/effect/spawner/random/entertainment/lighter{
+	pixel_x = 9
+	},
+/obj/effect/spawner/random/entertainment/lighter{
+	pixel_x = 9
+	},
+/obj/structure/sign/poster/contraband/kss13/directional/east,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/gas_station)
+"WI" = (
+/obj/structure/flora/rock/icy/style_3,
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/misc/asteroid/moon,
+/area/ruin/space/has_grav/gas_station)
+"Xy" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ruin/space/has_grav/gas_station)
+"XF" = (
+/turf/open/space/basic,
+/area/space)
+"XK" = (
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/gas_station)
+"Yo" = (
+/obj/machinery/bluespace_vendor/directional/north,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/turf/open/floor/iron/dark/textured_edge,
+/area/ruin/space/has_grav/gas_station)
+"Yx" = (
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/traitor_rune,
+/turf/open/floor/iron/dark/textured,
+/area/ruin/space/has_grav/gas_station)
+"ZU" = (
+/obj/item/kirbyplants/random/dead,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/turf/open/floor/iron/dark/textured_edge,
+/area/ruin/space/has_grav/gas_station)
+
+(1,1,1) = {"
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+"}
+(2,1,1) = {"
+XF
+XF
+XF
+XF
+ae
+Gu
+lI
+xU
+ae
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+"}
+(3,1,1) = {"
+XF
+XF
+XF
+XF
+DY
+lI
+lI
+lI
+MA
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+"}
+(4,1,1) = {"
+XF
+XF
+XF
+re
+xx
+nn
+wI
+nn
+nn
+qJ
+Ew
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+"}
+(5,1,1) = {"
+XF
+XF
+XF
+jc
+nn
+Jh
+bH
+NH
+nn
+pg
+He
+yO
+KQ
+vD
+XF
+XF
+XF
+XF
+XF
+XF
+"}
+(6,1,1) = {"
+XF
+XF
+XF
+lI
+wI
+Tq
+bq
+yQ
+wI
+Gu
+hz
+oa
+Gu
+vo
+eE
+XF
+XF
+XF
+XF
+XF
+"}
+(7,1,1) = {"
+XF
+XF
+XF
+lI
+nn
+zA
+yd
+Mx
+nn
+iZ
+TO
+TO
+TO
+Ig
+uL
+xx
+XF
+XF
+XF
+XF
+"}
+(8,1,1) = {"
+XF
+XF
+XF
+lI
+nn
+nn
+wc
+nn
+nn
+qh
+Sk
+zr
+XK
+vo
+vX
+EE
+XF
+XF
+XF
+XF
+"}
+(9,1,1) = {"
+XF
+XF
+XF
+Gu
+nn
+kp
+Lt
+hm
+nn
+Nd
+JK
+nn
+uy
+vo
+vo
+LB
+XF
+XF
+XF
+XF
+"}
+(10,1,1) = {"
+XF
+XF
+XF
+nm
+wI
+Wj
+vg
+nj
+wI
+vo
+wa
+nn
+Yo
+vo
+vo
+He
+DO
+XF
+XF
+XF
+"}
+(11,1,1) = {"
+XF
+XF
+XF
+RW
+wI
+Gx
+Rb
+ZU
+wI
+vo
+qg
+sv
+Mf
+vo
+vo
+VQ
+IG
+XF
+XF
+XF
+"}
+(12,1,1) = {"
+XF
+XF
+XF
+ks
+wI
+pp
+Yx
+Cs
+Xy
+Vn
+vo
+Ig
+Cb
+vo
+vo
+vo
+rp
+XF
+XF
+XF
+"}
+(13,1,1) = {"
+XF
+XF
+XF
+Oj
+wI
+Tp
+qU
+vB
+Xy
+vo
+Sk
+zr
+XK
+vo
+vo
+vo
+OD
+XF
+XF
+XF
+"}
+(14,1,1) = {"
+XF
+XF
+XF
+lI
+nn
+gJ
+vv
+nd
+wI
+MS
+Uf
+nn
+aB
+vo
+Cb
+JI
+qs
+XF
+XF
+XF
+"}
+(15,1,1) = {"
+XF
+XF
+XF
+lI
+nn
+Vb
+IM
+NZ
+wI
+Mc
+wa
+nn
+Yo
+vo
+vo
+OD
+XF
+XF
+XF
+XF
+"}
+(16,1,1) = {"
+XF
+XF
+XF
+lI
+xx
+nn
+Wl
+mr
+nn
+bZ
+qg
+sv
+Mf
+Ig
+vo
+OD
+XF
+XF
+XF
+XF
+"}
+(17,1,1) = {"
+XF
+XF
+XF
+TO
+ta
+nn
+nn
+nn
+xx
+oS
+Uy
+vk
+Gu
+eE
+uj
+xt
+XF
+XF
+XF
+XF
+"}
+(18,1,1) = {"
+XF
+XF
+XF
+XF
+LJ
+Gu
+Gu
+IJ
+lI
+lI
+WI
+jV
+MU
+tt
+XF
+XF
+XF
+XF
+XF
+XF
+"}
+(19,1,1) = {"
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+lI
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+"}
+(20,1,1) = {"
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+XF
+"}

--- a/_maps/RandomRuins/SpaceRuins/old_transport.dmm
+++ b/_maps/RandomRuins/SpaceRuins/old_transport.dmm
@@ -1,0 +1,839 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ag" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/xenoblood/xgibs/larva/body,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"bh" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 25
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/has_grav/old_transport)
+"cM" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"cU" = (
+/obj/effect/spawner/random/entertainment/cigarette,
+/turf/open/space/basic,
+/area/space)
+"dm" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating/dumpsterair,
+/area/ruin/space/has_grav/old_transport)
+"dG" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"ee" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/xenoblood/xgibs/torso,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/has_grav/old_transport)
+"eA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/old_transport)
+"fb" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/storage/box/rubbershot,
+/obj/item/gun/ballistic/shotgun,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"ha" = (
+/obj/item/kirbyplants/organic/plant3,
+/turf/open/space/basic,
+/area/space)
+"hl" = (
+/obj/effect/decal/cleanable/plastic,
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/old_transport)
+"hJ" = (
+/obj/effect/spawner/random/entertainment/money_small,
+/turf/open/space/basic,
+/area/space)
+"hS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/emergency,
+/obj/item/gps/spaceruin{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/has_grav/old_transport)
+"hW" = (
+/obj/structure/sign/warning/secure_area,
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/has_grav/old_transport)
+"iw" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/old_transport)
+"ju" = (
+/turf/open/space/basic,
+/area/ruin/space/has_grav/old_transport)
+"jC" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"kb" = (
+/turf/open/space/basic,
+/area/space)
+"lI" = (
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/has_grav/old_transport)
+"mV" = (
+/obj/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/old_transport)
+"nt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/dumpsterair,
+/area/ruin/space/has_grav/old_transport)
+"nI" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"nQ" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/old_transport)
+"oh" = (
+/obj/structure/window/reinforced/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/old_transport)
+"oG" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/machinery/light/red/directional/west,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/old_transport)
+"qz" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plating/dumpsterair,
+/area/ruin/space/has_grav/old_transport)
+"qJ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"rz" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"rJ" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/old_transport)
+"tQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"uh" = (
+/obj/machinery/power/shuttle_engine/heater,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/old_transport)
+"uO" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/dumpsterair,
+/area/ruin/space/has_grav/old_transport)
+"vB" = (
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/old_transport)
+"wn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating/dumpsterair,
+/area/ruin/space/has_grav/old_transport)
+"wH" = (
+/obj/machinery/power/shuttle_engine/propulsion{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
+"wM" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/spawner/random/entertainment/plushie,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/old_transport)
+"xs" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"yK" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"CE" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"CF" = (
+/obj/machinery/computer/terminal{
+	content = list("Property of Spinward-Upsilon Sanitation Department. Authorised employees only.");
+	desc = "A garbage truck's dusty old control console.";
+	name = "dashboard";
+	upperinfo = "Controls locked."
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"Do" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/spawner/random/entertainment/drugs,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/old_transport)
+"Dr" = (
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/turf/open/space/basic,
+/area/space)
+"FE" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"He" = (
+/obj/machinery/power/smes,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/light/red/directional/south,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/has_grav/old_transport)
+"HR" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/old_transport)
+"Jc" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/spawner/random/entertainment/toy,
+/turf/open/space/basic,
+/area/space)
+"Kq" = (
+/obj/structure/closet/crate/internals,
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"KA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/old_transport)
+"Mq" = (
+/obj/machinery/computer{
+	name = "Shuttle computer"
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"MJ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/entertainment/wallet_storage,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"MR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/old_transport)
+"Np" = (
+/obj/structure/closet/crate/internals,
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/old_transport)
+"Nt" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mob_spawn/corpse/human/bridgeofficer,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"Nw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/xenoblood/xgibs/down,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/has_grav/old_transport)
+"QU" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/stock_parts/cell/lead;
+	locked = 0;
+	pixel_y = -25;
+	start_charge = 0
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/spawner/random/entertainment/cigarette,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"Ra" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"Rq" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/old_transport)
+"Rx" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space)
+"RB" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/old_transport)
+"RP" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/decal/cleanable/xenoblood/xgibs/body,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"Sc" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/space/basic,
+/area/space)
+"Se" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/empty,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/textured,
+/area/ruin/space/has_grav/old_transport)
+"Sr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/dumpsterair,
+/area/ruin/space/has_grav/old_transport)
+"SE" = (
+/obj/machinery/power/shuttle_engine/propulsion,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/old_transport)
+"Ty" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/old_transport)
+"Ua" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/dumpsterair,
+/area/ruin/space/has_grav/old_transport)
+"Up" = (
+/obj/item/kirbyplants/organic/plant18,
+/turf/open/space/basic,
+/area/space)
+"UB" = (
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/old_transport)
+"UC" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/has_grav/old_transport)
+"WX" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating/dumpsterair,
+/area/ruin/space/has_grav/old_transport)
+"Xz" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/old_transport)
+"Zw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/old_transport)
+"ZE" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/space/has_grav/old_transport)
+
+(1,1,1) = {"
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+"}
+(2,1,1) = {"
+kb
+kb
+Xz
+lI
+RB
+lI
+rJ
+kb
+kb
+Jc
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+"}
+(3,1,1) = {"
+kb
+Rq
+lI
+lI
+oh
+lI
+lI
+Xz
+Up
+kb
+kb
+kb
+kb
+Rq
+Np
+Xz
+ZE
+kb
+kb
+kb
+"}
+(4,1,1) = {"
+kb
+Xz
+UC
+Mq
+nI
+QU
+lI
+lI
+oh
+Xz
+kb
+kb
+kb
+RB
+lI
+kb
+kb
+kb
+Dr
+kb
+"}
+(5,1,1) = {"
+kb
+wM
+oh
+CF
+cM
+Nt
+mV
+fb
+WX
+lI
+ag
+kb
+nQ
+hW
+lI
+uh
+SE
+kb
+kb
+kb
+"}
+(6,1,1) = {"
+kb
+HR
+oh
+yK
+Se
+tQ
+xs
+Ra
+hl
+oG
+Ua
+jC
+rz
+lI
+HR
+kb
+hJ
+kb
+kb
+kb
+"}
+(7,1,1) = {"
+kb
+HR
+oh
+hS
+Zw
+Nw
+xs
+MR
+uO
+dG
+wn
+CE
+UB
+HR
+kb
+kb
+kb
+kb
+kb
+kb
+"}
+(8,1,1) = {"
+kb
+Do
+oh
+Ty
+ee
+iw
+mV
+qJ
+nt
+MJ
+Sr
+RP
+qz
+kb
+kb
+wH
+Rx
+kb
+kb
+kb
+"}
+(9,1,1) = {"
+kb
+Xz
+lI
+bh
+eA
+He
+lI
+dm
+FE
+KA
+Kq
+oh
+UC
+uh
+kb
+kb
+kb
+kb
+kb
+kb
+"}
+(10,1,1) = {"
+kb
+vB
+lI
+lI
+oh
+lI
+UC
+lI
+lI
+ju
+lI
+kb
+Xz
+kb
+lI
+rJ
+kb
+kb
+cU
+kb
+"}
+(11,1,1) = {"
+kb
+kb
+RB
+lI
+rJ
+lI
+Xz
+kb
+lI
+RB
+Sc
+kb
+kb
+ha
+kb
+hW
+RB
+ZE
+kb
+kb
+"}
+(12,1,1) = {"
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+kb
+"}

--- a/_maps/RandomRuins/SpaceRuins/old_transport.dmm
+++ b/_maps/RandomRuins/SpaceRuins/old_transport.dmm
@@ -80,7 +80,7 @@
 /turf/open/floor/iron/textured,
 /area/ruin/space/has_grav/old_transport)
 "ha" = (
-/obj/item/kirbyplants/organic/plant3,
+/obj/item/kirbyplants/random/dead,
 /turf/open/space/basic,
 /area/space)
 "hl" = (
@@ -156,6 +156,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/plastic,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/textured,
 /area/ruin/space/has_grav/old_transport)
 "nQ" = (
@@ -368,6 +371,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating/rust,
 /area/ruin/space/has_grav/old_transport)
 "Mq" = (
@@ -473,6 +479,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/textured,
 /area/ruin/space/has_grav/old_transport)
 "Rq" = (
@@ -534,10 +541,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/dumpsterair,
 /area/ruin/space/has_grav/old_transport)
-"Up" = (
-/obj/item/kirbyplants/organic/plant18,
-/turf/open/space/basic,
-/area/space)
 "UB" = (
 /turf/open/floor/plating/rust,
 /area/ruin/space/has_grav/old_transport)
@@ -567,6 +570,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/old_transport)
 "ZE" = (
@@ -626,8 +630,8 @@ oh
 lI
 lI
 Xz
-Up
 kb
+ha
 kb
 kb
 kb

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -514,3 +514,8 @@
 	name = "Space-Ruin Decommissioned Garbage Truck NX4"
 	description = "An NX-760 interstellar transport barge. At the end of their life cycle, they are often filled with trash and launched into unexplored space to become someone else's problem. This one is full of commercial trash, and spiders."
 
+/datum/map_template/ruin/space/old_transport
+	id = "old_transport"
+	suffix = "old_transport.dmm"
+	name = "Space-Ruin old Nanotrasen transport ship XY-0898"
+	description = "XY-0898 is an old model that undertook transport missions for a long time, but it is of high quality. It has been unreachable for a long time."

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -519,3 +519,9 @@
 	suffix = "old_transport.dmm"
 	name = "Space-Ruin old Nanotrasen transport ship XY-0898"
 	description = "XY-0898 is an old model that undertook transport missions for a long time, but it is of high quality. It has been unreachable for a long time."
+
+/datum/map_template/ruin/space/gas_station
+	id = "gas_station"
+	suffix = "gas_station.dmm"
+	name = "Space-Ruin old Nanotrasen Gas Station"
+	description = "The last records of the old Nanotrasen gas station indicate an attempted robbery."

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -699,3 +699,7 @@
 /area/ruin/space/has_grav/garbagetruck/medicalwaste
 /area/ruin/space/has_grav/garbagetruck/squat
 /area/ruin/space/has_grav/garbagetruck/toystore
+
+//Old Transport Ship
+/area/ruin/space/has_grav/old_transport
+	name = "Old Transport Ship"

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -703,3 +703,7 @@
 //Old Transport Ship
 /area/ruin/space/has_grav/old_transport
 	name = "Old Transport Ship"
+
+//Gas Station
+/area/ruin/space/has_grav/gas_station
+	name = "Old Gas Station"

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -83,3 +83,4 @@
 #_maps/RandomRuins/SpaceRuins/waystation.dmm
 #_maps/RandomRuins/SpaceRuins/whiteshipdock.dmm
 #_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
+#_maps/RandomRuins/SpaceRuins/old_transport.dmm

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -84,3 +84,4 @@
 #_maps/RandomRuins/SpaceRuins/whiteshipdock.dmm
 #_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
 #_maps/RandomRuins/SpaceRuins/old_transport.dmm
+#_maps/RandomRuins/SpaceRuins/gas_station.dmm


### PR DESCRIPTION
## Pull Request Hakkında

Düşününce uzayın dop dolu bir yer olması gerekir elbet ana oyun istasyon içerisinde gerçekleşiyor ancak uzay ruinleri sadece powergaming yeri olmamalı.

## Oyun İçin Neden Gerekli

Daha fazla ruin daha çok hikaye dolu uzay daha az powergaming...
![Ekran görüntüsü 2024-06-21 182757](https://github.com/psychonaut-station/PsychonautStation/assets/157297522/e3b4a6d7-46d9-4a85-9348-4f224f0eb74e)
![Ekran görüntüsü 2024-06-21 182819](https://github.com/psychonaut-station/PsychonautStation/assets/157297522/05f84944-23b3-47b1-85ff-4ecbf5b7dc98)

Güncel halinde pompalı sayısı 1 adet.

## Changelog

Eski uzay gemisi ruini ekler.

:cl:
add: Eski uzay gemisi ruini ekler.
add: Soyulmuş Gaz İstasyonu ruini ekler.
/:cl:
