### PR TITLE
Jukebox log

### DIFF
--- a/code/__DEFINES/logging.dm
+++ b/code/__DEFINES/logging.dm
@@ -145,6 +145,7 @@
 #define LOG_CATEGORY_GAME_ACCESS "game-access"
 #define LOG_CATEGORY_GAME_EMOTE "game-emote"
 #define LOG_CATEGORY_GAME_INTERNET_REQUEST "game-internet-request"
+#define LOG_CATEGORY_GAME_JUKEBOX "game-jukebox"
 #define LOG_CATEGORY_GAME_OOC "game-ooc"
 #define LOG_CATEGORY_GAME_LOOC "game-looc"
 #define LOG_CATEGORY_GAME_PRAYER "game-prayer"

--- a/code/__HELPERS/logging/game.dm
+++ b/code/__HELPERS/logging/game.dm
@@ -13,7 +13,7 @@
 /// Logging for messages sent in OOC
 /proc/log_ooc(text, list/data)
 	logger.Log(LOG_CATEGORY_GAME_OOC, text, data)
-	
+
 /// Logging for messages sent in OOC
 /proc/log_looc(text, list/data)
 	logger.Log(LOG_CATEGORY_GAME_LOOC, text, data)
@@ -25,6 +25,10 @@
 /// Logging for music requests
 /proc/log_internet_request(text, list/data)
 	logger.Log(LOG_CATEGORY_GAME_INTERNET_REQUEST, text, data)
+
+/// Logging for e-jukebox
+/proc/log_jukebox(text, list/data)
+	logger.Log(LOG_CATEGORY_GAME_JUKEBOX, text, data)
 
 /// Logging for logging in & out of the game, with error messages.
 /proc/log_access(text, list/data)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -88,6 +88,9 @@
 ///Log Music Requests
 /datum/config_entry/flag/log_internet_request
 
+///Log e-jukebox
+/datum/config_entry/flag/log_jukebox
+
 /// log silicons
 /datum/config_entry/flag/log_silicon
 

--- a/code/datums/components/web_sound_player.dm
+++ b/code/datums/components/web_sound_player.dm
@@ -136,6 +136,8 @@ GLOBAL_LIST_EMPTY(web_track_cache)
 
 /datum/component/web_sound_player/Topic(href, list/href_list)
 	. = ..()
+	if(!check_rights(R_SOUND))
+		return
 	if(href_list["stop"])
 		if(stop())
 			var/atom/atom_parent = parent
@@ -153,6 +155,8 @@ GLOBAL_LIST_EMPTY(web_track_cache)
 
 /datum/component/web_sound_player/vv_do_topic(list/href_list)
 	. = ..()
+	if(!check_rights(R_SOUND))
+		return
 	if(href_list[VV_HK_PLAY_URL])
 		var/url = input(usr, "Enter content URL (youtube only)", "Play URL") as text|null
 		if(length(url) && play_url(url))

--- a/code/game/machinery/electrical_jukebox.dm
+++ b/code/game/machinery/electrical_jukebox.dm
@@ -163,10 +163,10 @@
 		var/client/client = GLOB.directory[ckey(track.mob_ckey)]
 
 		if(!queued)
-			log_admin("[key_name(client)] played web sound [track.webpage_url] on [src] at [area_name]")
+			log_jukebox("[key_name(client)] played web sound [track.webpage_url] on [src] at [area_name]")
 			message_admins("[key_name(client, TRUE)] played web sound [track.webpage_url_html] on [src] at [area_name]. [ADMIN_QUE(client.mob)] [ADMIN_JMP(src)] [STOP(src)] [BANJUKEBOX(src, client)]")
 		else
-			log_admin("Playing web sound [track.webpage_url] on [src] added by [key_name(client)] at [area_name]")
+			log_jukebox("Playing web sound [track.webpage_url] on [src] added by [key_name(client)] at [area_name]")
 			message_admins("Playing web sound [track.webpage_url_html] on [src] added by [key_name(client, TRUE)] at [area_name]. [ADMIN_QUE(client.mob)] [ADMIN_JMP(src)] [STOP(src)] [BANJUKEBOX(src, client)]")
 
 		SSblackbox.record_feedback("nested tally", "jukebox_played_url", 1, list("[client.ckey]", "[track.webpage_url]"))
@@ -215,11 +215,11 @@
 
 	if(request)
 		LAZYADD(requests, track)
-		log_admin("[key_name(user)] requested a web sound [track.webpage_url_html] on [src] at [area_name]")
+		log_jukebox("[key_name(user)] requested a web sound [track.webpage_url_html] on [src] at [area_name]")
 		message_admins("[key_name(user, TRUE)] requested a web sound [track.webpage_url_html] on [src] at [area_name]. [ADMIN_QUE(user)] [ADMIN_JMP(src)] [DENYREQUEST(src, track)] [BANJUKEBOX(src, user.client)]")
 	else
 		LAZYADD(queue, track)
-		log_admin("[key_name(user)] added web sound [track.webpage_url_html] to queue on [src] at [area_name]")
+		log_jukebox("[key_name(user)] added web sound [track.webpage_url_html] to queue on [src] at [area_name]")
 		message_admins("[key_name(user, TRUE)] added web sound [track.title] to queue on [src] at [area_name]. [ADMIN_QUE(user)] [ADMIN_JMP(src)] [REMOVEQUEUE(src, track)] [BANJUKEBOX(src, user.client)]")
 
 /obj/machinery/electrical_jukebox/proc/check_input(mob/user, input)

--- a/code/modules/logging/categories/log_category_game.dm
+++ b/code/modules/logging/categories/log_category_game.dm
@@ -17,6 +17,11 @@
 	config_flag = /datum/config_entry/flag/log_internet_request
 	master_category = /datum/log_category/game
 
+/datum/log_category/game_jukebox
+	category = LOG_CATEGORY_GAME_JUKEBOX
+	config_flag = /datum/config_entry/flag/log_jukebox
+	master_category = /datum/log_category/game
+
 /datum/log_category/game_radio_emote
 	category = LOG_CATEGORY_GAME_RADIO_EMOTE
 	config_flag = /datum/config_entry/flag/log_emote
@@ -41,7 +46,7 @@
 	category = LOG_CATEGORY_GAME_WHISPER
 	config_flag = /datum/config_entry/flag/log_whisper
 	master_category = /datum/log_category/game
-	
+
 /datum/log_category/game_hallucination
 	category = LOG_CATEGORY_GAME_HALLUCINATION
 	config_flag = /datum/config_entry/flag/log_hallucination

--- a/config/logging.txt
+++ b/config/logging.txt
@@ -104,3 +104,6 @@ LOG_WHISPER
 
 ## log manual target zone switching
 LOG_ZONE_SWITCH
+
+## log e-jukebox
+LOG_JUKEBOX


### PR DESCRIPTION

## Pull Request Hakkında
jukebox'ın admin log'unda olmaması gerek çünkü admin aksiyonu değil. jukebox'da şarkıya engel olma vs hala admin logunda ve component olan jukebox da admin logunda

## Oyun İçin Neden Gerekli
doğru kategorizasyon

## Changelog
:cl:
admin: Jukebox'ın logu admin log yerine game log'da olucak
/:cl:
