### PR TITLE
Blue alert açıklama değişimi

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -163,10 +163,10 @@
 	default = "İstasyona yönelik tüm tehditler geçmiştir. Güvenlik görevlileri silah bulundurmayabilir, gizliliğinize tekrardan önem verilmektedir."
 
 /datum/config_entry/string/alert_blue_upto
-	default = "İstasyona olası düşmanca faaliyetler hakkında güvenilir bir bilgi geldi. Güvenlik görevlileri silah bulundurabilir, rastgele aramalara izin verilmektedir."
+	default = "İstasyona olası düşmanca faaliyetler hakkında güvenilir bir bilgi geldi. Güvenlik görevlileri silah bulundurabilir, aramalara geçerli bir sebebi olması dahilinde izin verilmektedir."
 
 /datum/config_entry/string/alert_blue_downto
-	default = "İstasyona yönelik tehdit geçmiştir. Güvenlik görevlileri artık silahlarını her an hazır tutmayabilir ancak bulundurmaya devam edebilir. Rastgele aramalara hala izin verilmektedir."
+	default = "İstasyona yönelik tehdit geçmiştir. Güvenlik görevlileri artık silahlarını her an hazır tutmayabilir ancak bulundurmaya devam edebilir. Aramalara geçerli bir sebebi olması dahilinde verilmektedir."
 
 /datum/config_entry/string/alert_red_upto
 	default = "İstasyona yönelik ciddi bir tehdit bulunuyor. Güvenlik görevlileri silahlarını her an kullanabilir. Rastgele aramalara izin verilmektedir ve tavsiye edilir."


### PR DESCRIPTION

## Pull Request Hakkında

Blue Alert uyarı mesajını tg wikisindeki standart operating procedures'a göre ayarlar
![image](https://github.com/user-attachments/assets/9643453d-bcf5-471c-a0e4-3f45b2567fb5)
## Oyun İçin Neden Gerekli

Oyuncuların birbiriyle daha fazla iletişime geçebilmesini sağlayacağını, shitsecliği biraz da olsa azaltacağını security - crew arası oluşan gereksiz escalationları azaltacağını ve bundan doğacak self antaglık durumlarını azaltacağını düşünüyorum. Wiki'de yazan alert kurallarının uygulanmasının daha doğru olduğunu düşünüyorum bu açıklama onun uygulanmasının önüne geçiyordu. Bazı command üyeleri secleri insanları zorla aramaya filan zorluyordu. Bu tarz tatsızlıkların önüne geçeceğini düşünüyorum. Her round insanları koridorda yürürken durduk yere baton yiyip çırıl çıplak soyulmalarını izliyorum. Rol kalitesini de düşürüyordu bu durum o yüzden böyle bir değişiklik yapmak istedim. 
## Changelog
:cl:
fix: Blue Alert açıklamasından "rastgele aramalara izin verilmektedir" ifadesini kaldırır," aramalara geçerli bir sebebi olması dahilinde izin verilmektedir " ifadesini ekler.
/:cl:
