### PR TITLE
RDnin hafızasına upload key eklenir.

### DIFF
--- a/code/datums/memory/key_memories.dm
+++ b/code/datums/memory/key_memories.dm
@@ -236,3 +236,26 @@
 		"Poly the parrot screaming \"[decrypt_key]!\" over and over again.",
 		"[protagonist_name] spilling coffee over the message monitor while typing [decrypt_key].",
 	)
+
+/datum/memory/key/silicon_decrypt_key
+	var/upload_key
+
+/datum/memory/key/silicon_decrypt_key/New(
+	datum/mind/memorizer_mind,
+	atom/protagonist,
+	atom/deuteragonist,
+	atom/antagonist,
+	upload_key,
+)
+	src.upload_key = upload_key
+	return ..()
+
+/datum/memory/key/silicon_decrypt_key/get_names()
+	return list("The secret silicon decryption key is [upload_key]. Keep it a secret from the clown.")
+
+/datum/memory/key/silicon_decrypt_key/get_starts()
+	return list(
+		"A sticky note attached to a locker with [upload_key] written on it.",
+		"Lamarr the facehugger jumps to a AI upload console with [upload_key] written on it over and over again.",
+		"[protagonist_name] spilling coffee over the AI upload console while typing [upload_key].",
+	)

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -46,6 +46,9 @@
 
 	voice_of_god_power = 1.4 //Command staff has authority
 
+/datum/job/research_director/after_spawn(mob/living/spawned, client/player_client)
+	. = ..()
+	spawned.add_mob_memory(/datum/memory/key/silicon_decrypt_key, upload_key = GLOB.upload_key)
 
 /datum/job/research_director/get_captaincy_announcement(mob/living/captain)
 	return "Personel eksikliği nedeniyle, yeni terfi eden geçici kaptan [captain.real_name] güvertede!"


### PR DESCRIPTION

## Pull Request Hakkında
Roundstart rdnin hafızasına law upload şifresini ekler
## Oyun İçin Neden Gerekli
Rdnin bunu zaten istasyona gönderilmeden bilmesi gerektigini düsünüyorum. Aynı Cenin message monitor şifresini bilmesi gibi.
## Changelog
:cl:
qol: Research Director artık law upload şifresini ezbere biliyor.
/:cl:
