### PR TITLE
Cami shuttleının kapısının yönü

### DIFF
--- a/_maps/shuttles/emergency_cami.dmm
+++ b/_maps/shuttles/emergency_cami.dmm
@@ -255,7 +255,9 @@
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "Du" = (
-/obj/machinery/scanner_gate/cami_shuttle,
+/obj/machinery/scanner_gate/cami_shuttle{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "El" = (


### PR DESCRIPTION

## Pull Request Hakkında

scanner gatelerin spritelar directional olmuş bundan dolayı cami shuttledaki scanner gate ters görünüyordu

## Oyun İçin Neden Gerekli

düzgün görünmesi daha iyi olur

## Changelog
:cl:
fix: Cami shuttleının kapısı düzgün görünecek
/:cl:
