### PR TITLE
Ipc living heart fix

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -216,9 +216,10 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 		return FALSE
 	if(!new_heart.useable)
 		return FALSE
-	if(new_heart.organ_flags & (ORGAN_ROBOTIC|ORGAN_FAILING))
+	if(new_heart.organ_flags & ORGAN_FAILING)
 		return FALSE
-
+	if((new_heart.organ_flags & ORGAN_ROBOTIC) && !istype(new_heart, /obj/item/organ/heart/cybernetic/tier2/ipc))
+		return FALSE
 	return TRUE
 
 /**


### PR DESCRIPTION
## Pull Request Hakkında
Tgye neden böyle diye sordugumda rp acısından + secler yakaladıkları hereticlerin kalplerini değiştirip durdurabilsinler diyeymiş yani herhangi bir sorun cıkartmıcaktır diye düşünüyorum
## Oyun İçin Neden Gerekli
Ipcler hereticlik yapamıyor, kötü olay.
önceden çözmüştüm sanıyodum ama çözmemişim
## Changelog
:cl:
fix: ipcler heretic kalbine sahip olabilecek
/:cl:
