### PR TITLE
Karakter görünümü exportlamak

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -807,3 +807,6 @@
 /datum/config_entry/flag/allow_tracy_queue
 	protection = CONFIG_ENTRY_LOCKED
 
+/datum/config_entry/number/seconds_cooldown_for_character_icon_export
+	default = 30
+	min_val = 1

--- a/code/datums/mocking/client.dm
+++ b/code/datums/mocking/client.dm
@@ -27,13 +27,16 @@
 	var/tgui_say
 	var/typing_indicators
 
-/datum/client_interface/New()
+/datum/client_interface/New(key)
 	..()
 	var/static/mock_client_uid = 0
-	mock_client_uid++
-
-	src.key = "[key]_[mock_client_uid]"
-	ckey = ckey(key)
+	if(key)
+		src.key = key
+		ckey = ckey(key)
+	else
+		mock_client_uid++
+		src.key = "[src.key]_[mock_client_uid]"
+		ckey = ckey(src.key)
 
 #ifdef UNIT_TESTS // otherwise this shit can leak into production servers which is drather bad
 	GLOB.directory[ckey] = src

--- a/code/datums/mocking/client.dm
+++ b/code/datums/mocking/client.dm
@@ -27,16 +27,12 @@
 	var/tgui_say
 	var/typing_indicators
 
-/datum/client_interface/New(key)
+/datum/client_interface/New()
 	..()
 	var/static/mock_client_uid = 0
-	if(key)
-		src.key = key
-		ckey = ckey(key)
-	else
-		mock_client_uid++
-		src.key = "[src.key]_[mock_client_uid]"
-		ckey = ckey(src.key)
+	mock_client_uid++
+	src.key = "[src.key]_[mock_client_uid]"
+	ckey = ckey(src.key)
 
 #ifdef UNIT_TESTS // otherwise this shit can leak into production servers which is drather bad
 	GLOB.directory[ckey] = src

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -64,6 +64,8 @@
 	COOLDOWN_DECLARE(say_slowmode)
 	/// The last urgent ahelp that this player sent
 	COOLDOWN_DECLARE(urgent_ahelp_cooldown)
+	/// The last exported character or prefererences icon that this player use
+	COOLDOWN_DECLARE(export_character_icon)
 
 		/////////
 		//OTHER//

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1353,6 +1353,44 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 	send2adminchat("Server", jointext(message_to_send, " "))
 
+/client/verb/export_preferences_icon()
+	set name = "Export Preferences Icon"
+	set category = "OOC"
+	if(is_guest_key(key))
+		return
+
+	var/icon/output_icon = icon('icons/effects/effects.dmi', "nothing")
+	var/atom/movable/screen/map_view/char_preview/character_preview_view
+	var/datum/client_interface/client_interface
+	var/datum/preferences/mocked_prefs
+
+	if(isnull(prefs.character_preview_view))
+		client_interface = new(ckey)
+		mocked_prefs = new(client_interface)
+		character_preview_view = new(null, mocked_prefs)
+		character_preview_view.update_body()
+	else
+		character_preview_view = prefs.character_preview_view
+
+	var/mutable_appearance/appearance = new(character_preview_view.appearance)
+	appearance.setDir(SOUTH)
+
+	for (var/direction in GLOB.cardinals)
+		var/icon/partial = getFlatIcon(appearance, defdir = direction, no_anim = TRUE)
+		output_icon.Insert(partial, dir = direction)
+
+	var/time = world.timeofday
+	var/finalpath = "tmp/character_icon_[ckey]_[time].png"
+
+	fcopy(output_icon, finalpath)
+
+	DIRECT_OUTPUT(usr, ftp(file(finalpath)))
+	if(!isnull(client_interface))
+		qdel(appearance)
+		qdel(character_preview_view)
+		qdel(mocked_prefs)
+		qdel(client_interface)
+
 #undef ADMINSWARNED_AT
 #undef CURRENT_MINUTE
 #undef CURRENT_SECOND

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1353,44 +1353,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 	send2adminchat("Server", jointext(message_to_send, " "))
 
-/client/verb/export_preferences_icon()
-	set name = "Export Preferences Icon"
-	set category = "OOC"
-	if(is_guest_key(key))
-		return
-
-	var/icon/output_icon = icon('icons/effects/effects.dmi', "nothing")
-	var/atom/movable/screen/map_view/char_preview/character_preview_view
-	var/datum/client_interface/client_interface
-	var/datum/preferences/mocked_prefs
-
-	if(isnull(prefs.character_preview_view))
-		client_interface = new(ckey)
-		mocked_prefs = new(client_interface)
-		character_preview_view = new(null, mocked_prefs)
-		character_preview_view.update_body()
-	else
-		character_preview_view = prefs.character_preview_view
-
-	var/mutable_appearance/appearance = new(character_preview_view.appearance)
-	appearance.setDir(SOUTH)
-
-	for (var/direction in GLOB.cardinals)
-		var/icon/partial = getFlatIcon(appearance, defdir = direction, no_anim = TRUE)
-		output_icon.Insert(partial, dir = direction)
-
-	var/time = world.timeofday
-	var/finalpath = "tmp/character_icon_[ckey]_[time].png"
-
-	fcopy(output_icon, finalpath)
-
-	DIRECT_OUTPUT(usr, ftp(file(finalpath)))
-	if(!isnull(client_interface))
-		qdel(appearance)
-		qdel(character_preview_view)
-		qdel(mocked_prefs)
-		qdel(client_interface)
-
 #undef ADMINSWARNED_AT
 #undef CURRENT_MINUTE
 #undef CURRENT_SECOND

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -269,6 +269,30 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				return FALSE
 
 			return TRUE
+		if ("export_character_icon")
+			if(!character_preview_view)
+				return FALSE
+
+			if(!COOLDOWN_FINISHED(parent, export_character_icon))
+				tgui_alert(usr, "You must wait [DisplayTimeText(COOLDOWN_TIMELEFT(parent, export_character_icon))] before exporting your character icon again!", "Export Character Icon")
+				return FALSE
+
+			COOLDOWN_START(parent, export_character_icon, (CONFIG_GET(number/seconds_cooldown_for_character_icon_export) * (1 SECONDS)))
+
+			var/icon/output_icon = icon('icons/effects/effects.dmi', "nothing")
+
+			character_preview_view.setDir(SOUTH)
+
+			for (var/direction in GLOB.cardinals)
+				var/icon/partial = getFlatIcon(character_preview_view, defdir = direction, no_anim = TRUE)
+				output_icon.Insert(partial, dir = direction)
+
+			var/time = world.timeofday
+			var/finalpath = "tmp/character_icon_[parent.ckey]_[time].png"
+
+			fcopy(output_icon, finalpath)
+
+			DIRECT_OUTPUT(usr, ftp(file(finalpath)))
 
 	for (var/datum/preference_middleware/preference_middleware as anything in middleware)
 		var/delegation = preference_middleware.action_delegations[action]

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -3039,3 +3039,23 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	if(HAS_TRAIT(src, TRAIT_ANALGESIA) && !force)
 		return
 	INVOKE_ASYNC(src, PROC_REF(emote), "scream")
+
+/mob/living/verb/export_character_icon()
+	set name = "Export Character Icon"
+	set category = "OOC"
+
+	var/mutable_appearance/living_appearance = new(appearance)
+	living_appearance.setDir(SOUTH)
+	var/icon/output_icon = icon('icons/effects/effects.dmi', "nothing")
+
+	for (var/direction in GLOB.cardinals)
+		var/icon/partial = getFlatIcon(living_appearance, defdir = direction, no_anim = TRUE)
+		output_icon.Insert(partial, dir = direction)
+
+	var/time = world.timeofday
+	var/finalpath = "tmp/character_icon_[real_name]_[time].png"
+
+	fcopy(output_icon, finalpath)
+
+	DIRECT_OUTPUT(usr, ftp(file(finalpath)))
+	qdel(living_appearance)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -3044,6 +3044,12 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	set name = "Export Character Icon"
 	set category = "OOC"
 
+	if(!COOLDOWN_FINISHED(client, export_character_icon))
+		tgui_alert(usr, "You must wait [DisplayTimeText(COOLDOWN_TIMELEFT(client, export_character_icon))] before exporting your character icon again!", "Export Character Icon")
+		return FALSE
+
+	COOLDOWN_START(client, export_character_icon, (CONFIG_GET(number/seconds_cooldown_for_character_icon_export) * (1 SECONDS)))
+
 	var/mutable_appearance/living_appearance = new(appearance)
 	living_appearance.setDir(SOUTH)
 	var/icon/output_icon = icon('icons/effects/effects.dmi', "nothing")

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
@@ -46,6 +46,7 @@ type CharacterControlsProps = {
   gender: Gender;
   setGender: (gender: Gender) => void;
   showGender: boolean;
+  handleExportIcon: () => void;
 };
 
 function CharacterControls(props: CharacterControlsProps) {
@@ -79,6 +80,15 @@ function CharacterControls(props: CharacterControlsProps) {
           />
         </Stack.Item>
       )}
+      <Stack.Item>
+        <Button
+          onClick={props.handleExportIcon}
+          fontSize="22px"
+          icon="download"
+          tooltip="Export Character Icon"
+          tooltipPosition="top"
+        />
+      </Stack.Item>
     </Stack>
   );
 }
@@ -586,6 +596,9 @@ export function MainPage(props: MainPageProps) {
                 showGender={
                   currentSpeciesData ? !!currentSpeciesData.sexes : true
                 }
+                handleExportIcon={() => {
+                  act('export_character_icon');
+                }}
               />
             </Stack.Item>
 


### PR DESCRIPTION
## Pull Request Hakkında

Oyundaki karakterimizin resmini bilgisayarımıza kaydedebilmemiz için verbler ekler. Birisi character preferences için, diğeri ise oyundaki aktif karakterimiz için.

Resimleri tmp klasorune kaydedip ordan oyuncuya gönderiyor, tmp klasoru zaten her server baslangıcında sıfırlanıyor yani dosyalar serverde yer kaplamayacak

### Export Character Icon
Oyunda şuanki aktif karakterimizin görüntüsünü bilgisayarımıza kaydetmemize olanak tanır.
![image](https://github.com/user-attachments/assets/0c0b8c8e-2bd8-4224-835a-4c677888a419)

### Export Preferences Icon
Eğerki oyuncunun character preferences menusu açıksa en yeni görünümü elde etmek için resmi ordan alır.
Tam tersi eğer menü kapalıysa client interface ve preferences oluşturup resmi oradan çeker, clientin kendi prefsinden almama sebebim menü kapalıyken prefsin resmi olmuyor ve resmi orjinal preferencesde oluşturursamda silinirken preferencese elliyor, o yüzden sahtesini oluşturmak daha mantıklı geldi.

![image](https://github.com/user-attachments/assets/54f83548-1639-4900-8d65-146e0ebe9a78)
## Oyun İçin Neden Gerekli

İnsanların karakterlerinin görünümüne ihtiyacı olunca screenshot almak zorunda olması bence kötü bir şey o yüzden bunu ekliyorum.
## Changelog
:cl: Rengan
add: Preferencesde oluşturduğunuz karakterinizin resmini indirebilmeniz için düğme eklendi.
add: Oyundaki aktif karakterinizin resmini indirebilmeniz için düğme eklendi. OOC > Export Character Icon
/:cl:
