### PR TITLE
Connected computer fix

### DIFF
--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -79,22 +79,42 @@
 	if(icon_state == "computer")
 		var/obj/machinery/computer/left_comp = null
 		var/obj/machinery/computer/right_comp = null
+		var/turf/left_turf = null
+		var/turf/right_turf = null
 		switch(dir)
 			if(NORTH)
-				left_comp = locate(/obj/machinery/computer) in get_step(src, WEST)
-				right_comp = locate(/obj/machinery/computer) in get_step(src, EAST)
+				left_turf = get_step(src, WEST)
+				right_turf = get_step(src, EAST)
 			if(EAST)
-				left_comp = locate(/obj/machinery/computer) in get_step(src, NORTH)
-				right_comp = locate(/obj/machinery/computer) in get_step(src, SOUTH)
+				left_turf = get_step(src, NORTH)
+				right_turf = get_step(src, SOUTH)
 			if(SOUTH)
-				left_comp = locate(/obj/machinery/computer) in get_step(src, EAST)
-				right_comp = locate(/obj/machinery/computer) in get_step(src, WEST)
+				left_turf = get_step(src, EAST)
+				right_turf = get_step(src, WEST)
 			if(WEST)
-				left_comp = locate(/obj/machinery/computer) in get_step(src, SOUTH)
-				right_comp = locate(/obj/machinery/computer) in get_step(src, NORTH)
-		if(!QDELETED(left_comp) && left_comp.dir == dir && left_comp.icon_state == "computer")
+				left_turf = get_step(src, SOUTH)
+				right_turf = get_step(src, NORTH)
+		for(var/obj/machinery/computer/computer in left_turf.contents)
+			if(QDELETED(computer))
+				continue
+			if(computer.dir != dir)
+				continue
+			if(computer.icon_state != "computer")
+				continue
+			left_comp = computer
+			break
+		for(var/obj/machinery/computer/computer in right_turf.contents)
+			if(QDELETED(computer))
+				continue
+			if(computer.dir != dir)
+				continue
+			if(computer.icon_state != "computer")
+				continue
+			right_comp = computer
+			break
+		if(!isnull(left_comp))
 			. += mutable_appearance('icons/psychonaut/obj/machines/connectors.dmi', "left")
-		if(!QDELETED(right_comp) && right_comp.dir == dir && right_comp.icon_state == "computer")
+		if(!isnull(right_comp))
 			. += mutable_appearance('icons/psychonaut/obj/machines/connectors.dmi', "right")
 
 	if(machine_stat & BROKEN)


### PR DESCRIPTION

## Pull Request Hakkında
1 noktada 2 bilgisayar olunca ve iconu computer olmayan bi bilgisayar locatelenince overlaylar bozuk oluyor.

Eskisi
![image](https://github.com/user-attachments/assets/33f70cda-de2b-477f-a74e-80b3b613eb41)

Düzeltilmiş hali (normalde burasıda bozuk gözüküyodu duvardaki bilgiayardan dolayı)
![Ekran görüntüsü 2025-05-16 025243](https://github.com/user-attachments/assets/f44de9de-1bd2-4620-a8f6-c221518ac3b0)

Yakında bu connected computerleri tg eklicek ve o zaman buna gerek kalmıcak zaten ama genede fixlemek istedim

## Oyun İçin Neden Gerekli

Fixler güzeldir.
## Changelog
:cl: Rengan
fix: Bir noktada 2 bilgisayar varken 2 bilgisayarın birleşme overlayı düzeltildi.
/:cl:
