### PR TITLE
Pixel Shifting

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -61,6 +61,9 @@
 #define COMSIG_KB_LIVING_VIEW_PET_COMMANDS "keybinding_living_view_pet_commands"
 #define COMSIG_KB_LIVING_FACECURSOR_DOWN "keybinding_living_facecursor_down"
 
+#define COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_DOWN "keybinding_living_item_pixelshift_down"
+#define COMSIG_KB_LIVING_PIXEL_SHIFT_DOWN "keybinding_living_pixelshift_down"
+
 //Mob
 #define COMSIG_KB_MOB_FACENORTH_DOWN "keybinding_mob_facenorth_down"
 #define COMSIG_KB_MOB_FACEEAST_DOWN "keybinding_mob_faceeast_down"

--- a/code/datums/components/pixel_shift.dm
+++ b/code/datums/components/pixel_shift.dm
@@ -1,0 +1,140 @@
+#define SHIFTING_PARENT 1
+#define SHIFTING_ITEMS 2
+#define PIXEL_SHIFTING "pixel_shifting"
+
+/datum/component/pixel_shift
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+	//what type of shifting parent is doing, or if they aren't shifting at all
+	var/shifting = FALSE
+	//the maximum amount we/an item can move
+	var/maximum_pixel_shift = 10
+	//If we are shifted
+	var/is_shifted = FALSE
+	//Allows atoms entering Parent's turf to pass through freely from given directions
+	var/passthroughable = NONE
+	//Amount of shifting necessary to make the parent passthroughable
+	var/passthrough_threshold = 8
+
+/datum/component/pixel_shift/Initialize(...)
+	. = ..()
+	if(!isliving(parent))
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/pixel_shift/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_KB_LIVING_PIXEL_SHIFT_DOWN, PROC_REF(pixel_shift_down))
+	RegisterSignal(parent, COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_DOWN, PROC_REF(item_pixel_shift_down))
+	RegisterSignal(parent, DEACTIVATE_KEYBIND(COMSIG_KB_LIVING_PIXEL_SHIFT_DOWN), PROC_REF(pixel_shift_up))
+	RegisterSignal(parent, DEACTIVATE_KEYBIND(COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_DOWN), PROC_REF(item_pixel_shift_up))
+	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(unpixel_shift))
+	RegisterSignal(parent, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, PROC_REF(pre_move_check))
+
+/datum/component/pixel_shift/UnregisterFromParent()
+	UnregisterSignal(parent, list(
+		COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_DOWN,
+		COMSIG_KB_LIVING_PIXEL_SHIFT_DOWN,
+		COMSIG_MOB_CLIENT_PRE_LIVING_MOVE,
+		COMSIG_MOVABLE_MOVED,
+		DEACTIVATE_KEYBIND(COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_DOWN),
+		DEACTIVATE_KEYBIND(COMSIG_KB_LIVING_PIXEL_SHIFT_DOWN),
+	))
+
+//locks our movement when holding our keybinds
+/datum/component/pixel_shift/proc/pre_move_check(mob/source, new_loc, direct)
+	SIGNAL_HANDLER
+	if(shifting)
+		pixel_shift(source, direct)
+		return COMSIG_MOB_CLIENT_BLOCK_PRE_LIVING_MOVE
+
+//Procs for shifting items
+
+/datum/component/pixel_shift/proc/item_pixel_shift_down()
+	SIGNAL_HANDLER
+	shifting = SHIFTING_ITEMS
+	return COMSIG_KB_ACTIVATED
+
+/datum/component/pixel_shift/proc/item_pixel_shift_up()
+	SIGNAL_HANDLER
+	shifting = FALSE
+
+//Procs for shifting mobs
+
+/datum/component/pixel_shift/proc/pixel_shift_down()
+	SIGNAL_HANDLER
+	shifting = SHIFTING_PARENT
+	return COMSIG_KB_ACTIVATED
+
+/datum/component/pixel_shift/proc/pixel_shift_up()
+	SIGNAL_HANDLER
+	shifting = FALSE
+
+/// Sets parent pixel offsets to default and deletes the component.
+/datum/component/pixel_shift/proc/unpixel_shift()
+	SIGNAL_HANDLER
+	passthroughable = NONE
+	if(is_shifted)
+		var/mob/living/owner = parent
+		owner.add_offsets(type, x_add = 0, y_add = 0)
+	qdel(src)
+
+/// In-turf pixel movement which can allow things to pass through if the threshold is met.
+/datum/component/pixel_shift/proc/pixel_shift(mob/source, direct)
+	passthroughable = NONE
+	var/mob/living/owner = parent
+	switch(shifting)
+		if(SHIFTING_ITEMS)
+			var/atom/pulled_atom = source.pulling
+			if(!isitem(pulled_atom))
+				return
+			var/obj/item/pulled_item = pulled_atom
+			switch(direct)
+				if(NORTH)
+					if(pulled_item.pixel_y <= maximum_pixel_shift + pulled_item.base_pixel_y)
+						pulled_item.pixel_y++
+				if(EAST)
+					if(pulled_item.pixel_x <= maximum_pixel_shift + pulled_item.base_pixel_x)
+						pulled_item.pixel_x++
+				if(SOUTH)
+					if(pulled_item.pixel_y >= -maximum_pixel_shift + pulled_item.base_pixel_y)
+						pulled_item.pixel_y--
+				if(WEST)
+					if(pulled_item.pixel_x >= -maximum_pixel_shift + pulled_item.base_pixel_x)
+						pulled_item.pixel_x--
+		if(SHIFTING_PARENT)
+			switch(direct)
+				if(NORTH)
+					if(owner.pixel_y <= maximum_pixel_shift + owner.base_pixel_y)
+						owner.pixel_y++
+						is_shifted = TRUE
+				if(EAST)
+					if(owner.pixel_x <= maximum_pixel_shift + owner.base_pixel_x)
+						owner.pixel_x++
+						is_shifted = TRUE
+				if(SOUTH)
+					if(owner.pixel_y >= -maximum_pixel_shift + owner.base_pixel_y)
+						owner.pixel_y--
+						is_shifted = TRUE
+				if(WEST)
+					if(owner.pixel_x >= -maximum_pixel_shift + owner.base_pixel_x)
+						owner.pixel_x--
+						is_shifted = TRUE
+
+	// Yes, I know this sets it to true for everything if more than one is matched.
+	// Movement doesn't check diagonals, and instead just checks EAST or WEST, depending on where you are for those.
+	if(owner.pixel_y > passthrough_threshold)
+		passthroughable |= EAST | SOUTH | WEST
+	else if(owner.pixel_y < -passthrough_threshold)
+		passthroughable |= NORTH | EAST | WEST
+	if(owner.pixel_x > passthrough_threshold)
+		passthroughable |= NORTH | SOUTH | WEST
+	else if(owner.pixel_x < -passthrough_threshold)
+		passthroughable |= NORTH | EAST | SOUTH
+
+/// Checks if the parent is considered passthroughable from a direction. Projectiles will ignore the check and hit.
+/datum/component/pixel_shift/proc/check_passable(atom/movable/mover, border_dir)
+	if(!isprojectile(mover) && !mover.throwing && (passthroughable & border_dir))
+		return TRUE
+
+
+#undef PIXEL_SHIFTING
+#undef SHIFTING_PARENT
+#undef SHIFTING_ITEMS

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -186,3 +186,29 @@
 		return
 	var/mob/M = user.mob
 	M.face_mouse = FALSE
+
+/datum/keybinding/living/item_pixel_shift
+	hotkey_keys = list("V")
+	name = "item_pixel_shift"
+	full_name = "Item Pixel Shift"
+	description = "Shift a pulled item's offset"
+	keybind_signal = COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_DOWN
+
+/datum/keybinding/living/item_pixel_shift/down(client/user)
+	. = ..()
+	if(.)
+		return
+	user.mob.AddComponent(/datum/component/pixel_shift)
+
+/datum/keybinding/living/pixel_shift
+	hotkey_keys = list("B")
+	name = "pixel_shift"
+	full_name = "Pixel Shift"
+	description = "Shift your characters offset."
+	keybind_signal = COMSIG_KB_LIVING_PIXEL_SHIFT_DOWN
+
+/datum/keybinding/living/pixel_shift/down(client/user)
+	. = ..()
+	if(.)
+		return
+	user.mob.AddComponent(/datum/component/pixel_shift)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -59,6 +59,10 @@
 	. = ..()
 	if(.)
 		return
+	var/datum/component/pixel_shift/pixel_shift = GetComponent(/datum/component/pixel_shift)
+	if(pixel_shift)
+		if(pixel_shift.check_passable(mover, border_dir))
+			return TRUE
 	if(mover.throwing)
 		var/mob/thrower = mover.throwing.get_thrower()
 		return (!density || (body_position == LYING_DOWN) || (thrower == src && !ismob(mover)))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1233,6 +1233,7 @@
 #include "code\datums\components\phylactery.dm"
 #include "code\datums\components\pinata.dm"
 #include "code\datums\components\pinnable_accessory.dm"
+#include "code\datums\components\pixel_shift.dm"
 #include "code\datums\components\plundering_attacks.dm"
 #include "code\datums\components\pricetag.dm"
 #include "code\datums\components\profound_fisher.dm"


### PR DESCRIPTION
<!-- Yazılarını başlıkların **ALTINA** ve yorumların **ÜSTÜNE** yaz, aksi takdirde görünmeyebilir. -->

## Pull Request Hakkında
Pixel shifting ekler.

Hem itemlerin hemde kendimizin o tiledeki konumunu 10 pixele kadar değiştireibliyoruz (duvara yaslanma 11 pixeldi sanırım)

https://github.com/user-attachments/assets/f3d5da56-39e3-4716-866e-5b2259d6b040


<!-- Pull Request'i açıkla. Lütfen her değişikliği belirttiğinden emin ol, aksi takdirde bu incelemeyi zorlaştırabilir ve maintainerları PR'ı mergelemekten vazgeçirebilir! -->

## Oyun İçin Neden Gerekli
Pixel shiftingin rol yapmaya katkısı olcagını düşünüyorum, hem itemin o tiledeki konumunu kaydırarak dekor işini daha iyi hale getiriyor, hemde kendimizi shiftlemek değişik sahneler ortaya çıkarabilir.
<!-- Yaptığın değişikliklerin yararlarını ve oyuna nasıl fayda sağladığını, özellikle de tartışmalı ve/veya geniş kapsamlı ise, savun. Yaptığın şeyin oyunu NEDEN geliştireceğini gerçekten açıklayamıyorsan, muhtemelen ilk etapta oyun için iyi değildir. -->

## Changelog

<!-- Eğer PR oyunun oyuncular veya adminler tarafından somut olarak gözlemlenebilecek yönlerini değiştiriyorsa, changelog eklemelisin. Eğer yaptığın değişiklikler oyuncuları veya adminleri ilgilendirmiyorsa, bu kısmı silebilirsin. Lütfen maintainerların uygun gördükleri takdirde tagları kaldırabileceğini ve ekleme yapabileceğini unutma. -->

:cl: Rengan
add: Pİxel Shifting eklendi.
/:cl:

<!-- Changelogun çalışması için her iki :cl: de gerekli! Oyun içinde değişikliği yapan kişi olarak GitHub kullanıcı adından farklı bir isim kullanmak istiyorsan ilk :cl:'nin sağına adını yazabilirsin. -->
<!-- Aynı tagdan birden fazla kullanabilirsin (bunlar sadece oyun içinde simge için kullanılıyor) ve gereksiz olanları silebilirsin. Bazı taglar hariç diğerleri PR içeriğinin bir özetinden ziyade oyuncuların değişikliklerden nasıl etkilenebileceğini göstermeli yani bunları bizim değil oyuncuların ve adminlerin anlayabileceği şekilde yazmalısın. -->
