### PR TITLE
IPC power cord fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ipc.dm
@@ -27,7 +27,7 @@
 	no_equip_flags = ITEM_SLOT_MASK
 	mutant_organs = list(
 		/obj/item/organ/voltage_protector,
-		// /obj/item/organ/cyberimp/arm/toolkit/power_cord
+		/obj/item/organ/cyberimp/arm/toolkit/power_cord
 	)
 	mutanteyes = /obj/item/organ/eyes/robotic/basic
 	mutantears = /obj/item/organ/ears/cybernetic

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -176,8 +176,7 @@
 			return
 		if(istype(stomach))
 			balloon_alert(ipc, "transfered power")
-			stomach.adjust_charge(-IPC_APC_POWER_GAIN)
-			cell.give(IPC_APC_POWER_GAIN)
+			cell.give(-stomach.adjust_charge(-IPC_APC_POWER_GAIN))
 		else
 			balloon_alert(ipc, "can't transfer power!")
 	return

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -176,7 +176,8 @@
 			return
 		if(istype(stomach))
 			balloon_alert(ipc, "transfered power")
-			cell.give(-stomach.adjust_charge(-IPC_APC_POWER_GAIN))
+			stomach.adjust_charge(-IPC_APC_POWER_GAIN)
+			cell.give(IPC_APC_POWER_GAIN)
 		else
 			balloon_alert(ipc, "can't transfer power!")
 	return

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -30,7 +30,7 @@
 	if(hand)
 		on_limb_detached(hand)
 	RegisterSignal(limb, COMSIG_BODYPART_REMOVED, PROC_REF(on_limb_detached))
-	RegisterSignal(limb, COMSIG_QDELETING, PROC_REF(on_limb_detached))
+	RegisterSignal(limb, COMSIG_QDELETING, PROC_REF(on_limb_qdel))
 	hand = limb
 
 /obj/item/organ/cyberimp/arm/proc/on_limb_detached(obj/item/bodypart/source)
@@ -38,6 +38,10 @@
 	if(source != hand || QDELETED(hand))
 		return
 	UnregisterSignal(hand, COMSIG_BODYPART_REMOVED)
+	UnregisterSignal(hand, COMSIG_QDELETING)
+	hand = null
+
+/obj/item/organ/cyberimp/arm/proc/on_limb_qdel()
 	UnregisterSignal(hand, COMSIG_QDELETING)
 	hand = null
 

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -42,6 +42,7 @@
 	hand = null
 
 /obj/item/organ/cyberimp/arm/proc/on_limb_qdel()
+	UnregisterSignal(hand, COMSIG_BODYPART_REMOVED)
 	UnregisterSignal(hand, COMSIG_QDELETING)
 	hand = null
 
@@ -104,6 +105,10 @@
 		return
 	UnregisterSignal(hand, list(COMSIG_BODYPART_REMOVED, COMSIG_QDELETING, COMSIG_ITEM_ATTACK_SELF))
 	hand = null
+
+/obj/item/organ/cyberimp/arm/toolkit/on_limb_qdel()
+	UnregisterSignal(hand, COMSIG_ITEM_ATTACK_SELF)
+	return ..()
 
 /obj/item/organ/cyberimp/arm/toolkit/proc/on_item_attack_self()
 	SIGNAL_HANDLER

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -30,6 +30,7 @@
 	if(hand)
 		on_limb_detached(hand)
 	RegisterSignal(limb, COMSIG_BODYPART_REMOVED, PROC_REF(on_limb_detached))
+	RegisterSignal(limb, COMSIG_QDELETING, PROC_REF(on_limb_detached))
 	hand = limb
 
 /obj/item/organ/cyberimp/arm/proc/on_limb_detached(obj/item/bodypart/source)
@@ -37,6 +38,7 @@
 	if(source != hand || QDELETED(hand))
 		return
 	UnregisterSignal(hand, COMSIG_BODYPART_REMOVED)
+	UnregisterSignal(hand, COMSIG_QDELETING)
 	hand = null
 
 /obj/item/organ/cyberimp/arm/toolkit
@@ -96,7 +98,7 @@
 /obj/item/organ/cyberimp/arm/toolkit/on_limb_detached(obj/item/bodypart/source)
 	if(source != hand || QDELETED(hand))
 		return
-	UnregisterSignal(hand, list(COMSIG_BODYPART_REMOVED, COMSIG_ITEM_ATTACK_SELF))
+	UnregisterSignal(hand, list(COMSIG_BODYPART_REMOVED, COMSIG_QDELETING, COMSIG_ITEM_ATTACK_SELF))
 	hand = null
 
 /obj/item/organ/cyberimp/arm/toolkit/proc/on_item_attack_self()

--- a/code/modules/surgery/organs/internal/stomach/stomach_ipc.dm
+++ b/code/modules/surgery/organs/internal/stomach/stomach_ipc.dm
@@ -108,8 +108,9 @@
 	to_chat(owner, span_notice("You absorb some of the shock into your body!"))
 
 /obj/item/organ/stomach/ipc/proc/adjust_charge(amount)
+	. = 0
 	if(cell)
-		cell.give(amount)
+		. = cell.give(amount)
 	humanowner.diag_hud_set_humancell()
 
 /obj/item/organ/stomach/ipc/proc/adjust_backup_charge(amount)


### PR DESCRIPTION
## Pull Request Hakkında
Create and destroyda toolset olan bir kol silinince toolsetten kolun referansı temizlenmediği için garbage hatası veriyor, bu pr onu düzeltir.

Tek tek hand variablesini weakref yapmak yerine böyle yapmak daha mantıklı geldi.

Ayrıca apcye şarj veremiyomuşuz onu da düzeltir.
## Oyun İçin Neden Gerekli
IPCde power cord olmazsa şarj olmak için tek yol kalıyor, hoş değil.
## Changelog
:cl: Rengan
add: IPCye power cord tekrar eklendi.
fix: IPCnin apcye şarj verememe sorunu düzeltildi.
/:cl:
