### PR TITLE
"youtube only" yazısını "soundcloud only" olarak değiştirir

### DIFF
--- a/code/datums/components/web_sound_player.dm
+++ b/code/datums/components/web_sound_player.dm
@@ -158,7 +158,7 @@ GLOBAL_LIST_EMPTY(web_track_cache)
 	if(!check_rights(R_SOUND))
 		return
 	if(href_list[VV_HK_PLAY_URL])
-		var/url = input(usr, "Enter content URL (youtube only)", "Play URL") as text|null
+		var/url = input(usr, "Enter content URL (soundcloud only)", "Play URL") as text|null
 		if(length(url) && play_url(url))
 			var/atom/atom_parent = parent
 			var/area_name = get_area_name(atom_parent, TRUE)

--- a/code/game/machinery/electrical_jukebox.dm
+++ b/code/game/machinery/electrical_jukebox.dm
@@ -249,7 +249,7 @@
 	return TRUE
 
 /obj/machinery/electrical_jukebox/proc/tgui_music_input(title)
-	var/input = tgui_input_text(usr, "Enter content URL (youtube only)", title)
+	var/input = tgui_input_text(usr, "Enter content URL (soundcloud only)", title)
 	if(input && usr.can_perform_action(src, FORBID_TELEKINESIS_REACH))
 		if(!findtext(input, regex(replacetext(CONFIG_GET(string/request_internet_allowed), ",", "|"), "i")))
 			return tgui_music_input(title)


### PR DESCRIPTION
<!-- Yazılarını başlıkların **ALTINA** ve yorumların **ÜSTÜNE** yaz, aksi takdirde görünmeyebilir. -->

## Pull Request Hakkında

eskiden sadece youtube idi şimdi ise tam tersi malesef

## Oyun İçin Neden Gerekli

yanlış yönlendirme

## Changelog

:cl:
fix: Jukebox'da yalnızca youtube oynatabildiği değil soundcloud oynatabildiği yazacak
/:cl:

<!-- Changelogun çalışması için her iki :cl: de gerekli! Oyun içinde değişikliği yapan kişi olarak GitHub kullanıcı adından farklı bir isim kullanmak istiyorsan ilk :cl:'nin sağına adını yazabilirsin. -->
<!-- Aynı tagdan birden fazla kullanabilirsin (bunlar sadece oyun içinde simge için kullanılıyor) ve gereksiz olanları silebilirsin. Bazı taglar hariç diğerleri PR içeriğinin bir özetinden ziyade oyuncuların değişikliklerden nasıl etkilenebileceğini göstermeli yani bunları bizim değil oyuncuların ve adminlerin anlayabileceği şekilde yazmalısın. -->
