### PR TITLE
Space vine buff

### DIFF
--- a/code/modules/events/space_vines/vine_controller.dm
+++ b/code/modules/events/space_vines/vine_controller.dm
@@ -125,9 +125,9 @@ GLOBAL_LIST_INIT(vine_mutations_list, init_vine_mutation_list())
 		return
 
 	/// Bonus spread for kudzu that has just started out (ie. with low vine count)
-	var/start_spread_bonus = max(5 - spread_multiplier * (vine_count ** 2) / 400, 0)
+	var/start_spread_bonus = max(20 - spread_multiplier * (vine_count ** 2) / 800, 0)
 	/// Base spread rate, depends solely on spread multiplier and vine count
-	var/spread_base = 0.5 * vine_count / spread_multiplier
+	var/spread_base = 1 * vine_count / spread_multiplier
 	/// Actual maximum spread rate for this process tick
 	var/spread_max = round(clamp(seconds_per_tick * (spread_base + start_spread_bonus), max(seconds_per_tick * minimum_spread_rate, 1), spread_cap))
 	var/amount_processed = 0


### PR DESCRIPTION

## Pull Request Hakkında

Space vine artık daha hızlı!!!

## Oyun İçin Neden Gerekli

Space vine yavaş yayıldığı ve erken farkedildiği bir senaryoda kolayca ortadan kaldırılabiliyor ve çoğunlukla tehdit oluşturmuyor. Bu değişiklik ile birlikte space vine'ın istasyon için biraz daha tehditkar olacağı; en azından orak, weedkiller gibi gereçlerin daha aktif kullanılabilme şansı yakalayacağını düşünüyorum.

## Changelog

:cl:
balance: Space vine'ın başlangıç yayılma bonusu 4 katına çıktı, yayılma çarpanı 0.5 yerine 1 oldu.
/:cl:
