### PR TITLE
Jobs Page Beyaz Yazı Fixi - Worker Survival Box fixi

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -100,6 +100,7 @@
 	internal_type = /obj/item/tank/internals/emergency_oxygen/engi
 
 /obj/item/storage/box/survival/worker/PopulateContents()
+	..()
 	new /obj/item/reagent_containers/cup/soda_cans/cola(src)
 
 // Syndie survival box

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/JobsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/JobsPage.tsx
@@ -277,7 +277,7 @@ function JobRow(props: JobRowProps) {
               onSelected={(value) => {
                 act('set_job_title', { job: name, new_title: value });
               }}
-              color=""
+              color="transparent"
               className="PreferencesMenu__Jobs__AltTitleDropdown"
             />
           </Stack.Item>

--- a/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
+++ b/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
@@ -113,74 +113,71 @@
     }
 
     &__departments {
-          &.head {
-            background: colors.bg(var(--department-color));
+      &.head {
+        background: colors.bg(var(--department-color));
 
-            .job-name {
-              font-weight: bold;
-            }
-          }
+        .job-name {
+          font-weight: bold;
+        }
+      }
 
-          background: var(--department-color);
-          border: var(--border-thickness-small) outset var(--department-color);
-          color: black;
+      background: var(--department-color);
+      border: var(--border-thickness-small) outset var(--department-color);
+      color: black;
 
-          > * {
-            height: calc(100% + 0.2em);
-            padding-bottom: 0.2em;
-          }
+      > * {
+        height: calc(100% + 0.2em);
+        padding-bottom: 0.2em;
+      }
 
-          .options {
-            margin-right: var(--space-xxs);
-            background: hsla(0, 0%, 0%, 0.2);
-            height: 100%;
+      .options {
+        margin-right: var(--space-xxs);
+        background: hsla(0, 0%, 0%, 0.2);
+        height: 100%;
 
-            .PreferencesMenu__JobSlotDropdown {
-              .Dropdown {
-                .Dropdown__control {
-                  background: transparent !important;
-                  border: none !important;
-                  box-shadow: none !important;
-                  padding: 0 2px;
+        .PreferencesMenu__JobSlotDropdown {
+          .Dropdown {
+            .Dropdown__control {
+              background: transparent !important;
+              border: none !important;
+              box-shadow: none !important;
+              padding: 0 2px;
 
-                  i {
-                    color: #ffffff !important;
-                    opacity: 0.8;
-                    text-shadow: none !important;
-                    transition: opacity 0.2s ease-in-out;
-                  }
+              i {
+                color: #ffffff !important;
+                opacity: 0.8;
+                text-shadow: none !important;
+                transition: opacity 0.2s ease-in-out;
+              }
 
-                  &:hover i {
-                    opacity: 1 !important;
-                  }
+              &:hover i {
+                opacity: 1 !important;
+              }
 
-                  &:before,
-                  &:after {
-                    display: none !important;
-                  }
-                }
+              &:before,
+              &:after {
+                display: none !important;
               }
             }
           }
+        }
+      }
 
-        &--Captain {
-          border: var(--border-thickness-medium)
-            outset
+      &--Captain {
+        border: var(--border-thickness-medium) outset hsla(60, 100%, 39.2%, 1);
+
+        &:first-child {
+          border-top: var(--border-thickness-medium) outset
             hsla(60, 100%, 39.2%, 1);
+        }
 
-          &:first-child {
-            border-top: var(--border-thickness-medium)
-              outset
-              hsla(60, 100%, 39.2%, 1);
-          }
-
-          .job-name {
-            font-size: 17px;
-            & .Dropdown__arrow-button {
-              margin-left: 5px;
-            }
+        .job-name {
+          font-size: 17px;
+          & .Dropdown__arrow-button {
+            margin-left: 5px;
           }
         }
+      }
 
       &__priority {
         border: var(--border-thickness-tiny) solid hsla(0, 0%, 0%, 0.3);
@@ -215,6 +212,7 @@
       display: inline-flex;
       align-items: center;
       justify-content: space-around;
+      color: var(--color-black);
 
       & .Dropdown__arrow-button {
         margin-right: 1px;


### PR DESCRIPTION

## Pull Request Hakkında
JobsPage'de Alternatif İsim Dropdownu yüzünden renkler beyaz olmuş, geri siyaha çevirir.

Workerin Survival boxunun içeriğini düzeltir.
<details>Öncesi: <img width="981" height="629" alt="Ekran görüntüsü 2026-07-11 212954" src="https://github.com/user-attachments/assets/5c98def1-b9de-43dd-8a07-49a663c658f8" />
<br>
Sonrası: 
<img width="974" height="625" alt="Ekran görüntüsü 2026-07-11 213004" src="https://github.com/user-attachments/assets/884996de-b571-4b20-a49d-3bcd2b96bdbb" />
</details>


## Oyun İçin Neden Gerekli

Beyaz yazı rengi kötü gözüküyor. Workerin zaten herkeste bulunan eşyaları olmaması iyi birşey değil.
## Changelog
:cl: Rengan
fix: Jobs page beyaz yazı rengi düzeltildi.
fix: Workerin survival boxunda yeterli ekipman olmaması düzeltildi.
/:cl:
