### PR TITLE
Fart nerf

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -567,11 +567,6 @@
 	special_screen_obj = "birthday"
 	special_screen_replace = FALSE
 
-/datum/mood_event/farted
-	description = "I had a massive dump!"
-	mood_change = 3
-	timeout = 3 MINUTES
-
 /datum/mood_event/basketball_score
 	description = "Swish! Nothing but net."
 	mood_change = 2

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -842,7 +842,6 @@
 
 /datum/emote/living/fart/get_sound(mob/living/user)
 	if(ishuman(user))
-		user.add_mood_event("farted", /datum/mood_event/farted)
 		return pick('sound/misc/fart1.ogg', 'sound/misc/fart2.ogg', 'sound/misc/fart3.ogg',
 					'sound/misc/fart4.ogg', 'sound/misc/fart5.ogg', 'sound/misc/fart6.ogg')
 


### PR DESCRIPTION

## Pull Request Hakkında

Farts are not funny

## Oyun İçin Neden Gerekli

Fart emote'u olması gerektiği "emote" konumunu kaybedip, verdiği avantaj sebebiyle diğer emotelara kıyasla daha çok oyuncular tarafından spamlanan bir "mood arttırma yolu" haline geldi. Çok abartı bir etkisi var mı bilmiyorum, bakmadım ama adil olması için avantajın kaldırılması daha iyi olur.

## Changelog

:cl:
balance: osurmak artık mood buff sağlamıyor.
/:cl:
