### PR TITLE
render_offline_appearance runtime fix + yeni unit test

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1360,6 +1360,16 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 
 	var/list/job_preferences = SANITIZE_LIST(selected_char?["job_preferences"])
 
+	var/datum/client_interface/mock_client = new /datum/client_interface
+	var/datum/preferences/preferences = new(mock_client)
+
+	for (var/datum/preference/preference as anything in get_preferences_in_priority_order())
+		var/saved_data = selected_char?[preference.savefile_key]
+		if(!saved_data)
+			continue
+		var/new_value = preference.deserialize(saved_data, preferences)
+		preferences.value_cache[preference.type] = new_value
+
 	var/datum/job/selected_job
 	var/highest_pref = 0
 

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1422,9 +1422,9 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 		var/saved_data = selected_char?[preference.savefile_key]
 		if(!saved_data)
 			continue
-		var/new_value = preference.deserialize(saved_data)
+		var/new_value = preference.deserialize(saved_data, preferences)
 
-		preference.apply_to_human(our_human, new_value)
+		preference.apply_to_human(our_human, new_value, preferences)
 
 	our_human.icon_render_keys = list()
 	our_human.update_body(is_creating = TRUE)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1361,7 +1361,7 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 	var/list/job_preferences = SANITIZE_LIST(selected_char?["job_preferences"])
 
 	var/datum/client_interface/mock_client = new /datum/client_interface
-	var/datum/preferences/preferences = new(mock_client)
+	var/datum/preferences/preferences = new(mock_client, FALSE)
 
 	for (var/datum/preference/preference as anything in get_preferences_in_priority_order())
 		var/saved_data = selected_char?[preference.savefile_key]

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -107,8 +107,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	value_cache = null
 	return ..()
 
-/datum/preferences/New(client/parent)
+/datum/preferences/New(client/parent, load_and_save = TRUE)
 	src.parent = parent
+	src.load_and_save = load_and_save
 
 	for (var/middleware_type in subtypesof(/datum/preference_middleware))
 		middleware += new middleware_type(src)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -297,6 +297,7 @@
 #include "reagent_recipe_collisions.dm"
 #include "reagent_transfer.dm"
 #include "recycle_recycling.dm"
+#include "render_offline_appearance.dm"
 #include "required_map_items.dm"
 #include "resist.dm"
 #include "reskin_validation.dm"

--- a/code/modules/unit_tests/render_offline_appearance.dm
+++ b/code/modules/unit_tests/render_offline_appearance.dm
@@ -3,7 +3,7 @@
 
 /datum/unit_test/render_offline_appearance/Run()
 	var/datum/client_interface/our_client = new /datum/client_interface
-	var/datum/preferences/preferences = new(our_client)
+	var/datum/preferences/preferences = new(our_client, FALSE)
 	var/mutable_appearance/appearance = render_offline_appearance(our_client.ckey)
 	TEST_ASSERT(appearance, "Appearance is not created")
 	TEST_ASSERT(istype(appearance), "Appearance is not mutable_appearance")

--- a/code/modules/unit_tests/render_offline_appearance.dm
+++ b/code/modules/unit_tests/render_offline_appearance.dm
@@ -3,7 +3,7 @@
 
 /datum/unit_test/render_offline_appearance/Run()
 	var/datum/client_interface/our_client = new /datum/client_interface
-	var/datum/preferences/preferences = new(our_client)
+	new /datum/preferences(our_client)
 	var/mutable_appearance/appearance = render_offline_appearance(our_client.ckey)
 	TEST_ASSERT(appearance, "Appearance is not created")
 	TEST_ASSERT(istype(appearance), "Appearance is not mutable_appearance")

--- a/code/modules/unit_tests/render_offline_appearance.dm
+++ b/code/modules/unit_tests/render_offline_appearance.dm
@@ -3,7 +3,7 @@
 
 /datum/unit_test/render_offline_appearance/Run()
 	var/datum/client_interface/our_client = new /datum/client_interface
-	var/datum/preferences/preferences = new(our_client, FALSE)
+	var/datum/preferences/preferences = new(our_client)
 	var/mutable_appearance/appearance = render_offline_appearance(our_client.ckey)
 	TEST_ASSERT(appearance, "Appearance is not created")
 	TEST_ASSERT(istype(appearance), "Appearance is not mutable_appearance")

--- a/code/modules/unit_tests/render_offline_appearance.dm
+++ b/code/modules/unit_tests/render_offline_appearance.dm
@@ -1,0 +1,9 @@
+/datum/unit_test/render_offline_appearance
+	test_flags = UNIT_TEST_FOCUS
+
+/datum/unit_test/render_offline_appearance/Run()
+	var/datum/client_interface/our_client = new /datum/client_interface
+	var/datum/preferences/preferences = new(our_client)
+	var/mutable_appearance/appearance = render_offline_appearance(our_client.ckey)
+	TEST_ASSERT(appearance, "Appearance is not created")
+	TEST_ASSERT(istype(appearance), "Appearance is not mutable_appearance")


### PR DESCRIPTION

## Pull Request Hakkında
son tg updatesinden sonra preference.apply_human procuna yeni bir parametre olarak /datum/preferences eklendi, render_offline_appearance de ise preferences kullanmadıgımız icin hata veriyor.
Çözüm olarak mock client kullandım, açıkçası aklıma başka bir fikir gelmedi. Bunun yerine proclara extra check vs de eklenebilir ama geçici bir çözüm olur gibi geldi.

## Oyun İçin Neden Gerekli

Runtime yüzünden render_offline_appearance calısmıyor ve hata veriyor.
## Changelog
Oyuncuları ilgilendirmiyor.
