### PR TITLE
Shark Plushie loadout

### DIFF
--- a/code/modules/loadout/categories/pocket.dm
+++ b/code/modules/loadout/categories/pocket.dm
@@ -94,6 +94,10 @@
 	name = "Plush (Horse)"
 	item_path = /obj/item/toy/plush/horse
 
+/datum/loadout_item/pocket_items/plush/shark
+	name = "Plush (Shark)"
+	item_path = /obj/item/toy/plush/shark
+
 /datum/loadout_item/pocket_items/dice
 	group = "Dice"
 	abstract_type = /datum/loadout_item/pocket_items/dice


### PR DESCRIPTION

## Pull Request Hakkında
Character Setupın loadout kısmına Shark Plushie ekler.
## Oyun İçin Neden Gerekli

Diğer plushieler varken shark plushienin olmaması için bir sebep yok, önceki toplantıda bir oyuncu getirilmesini istedi ve bence isteyen daha fazla kişi de vardır.
## Changelog
:cl:
add: Loadouta shark plushie ekler.
/:cl:
