### PR TITLE
RenderOfflineAppearance Fix + Unit Test

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1360,6 +1360,16 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 
 	var/list/job_preferences = SANITIZE_LIST(selected_char?["job_preferences"])
 
+	var/datum/client_interface/mock_client = new /datum/client_interface
+	var/datum/preferences/preferences = new(mock_client)
+
+	for (var/datum/preference/preference as anything in get_preferences_in_priority_order())
+		var/saved_data = selected_char?[preference.savefile_key]
+		if(!saved_data)
+			continue
+		var/new_value = preference.deserialize(saved_data, preferences)
+		preferences.value_cache[preference.type] = new_value
+
 	var/datum/job/selected_job
 	var/highest_pref = 0
 

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1400,6 +1400,8 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 			appearance.icon_state = resolve_ai_icon_sync(ai_core_value)
 			if(GLOB.ai_core_display_screen_icons.Find(ai_core_value))
 				appearance.icon = GLOB.ai_core_display_screen_icons[ai_core_value]
+		qdel(mock_client)
+		qdel(preferences)
 		if(!only_appearance)
 			return list(
 				"name" = mob_name,
@@ -1472,8 +1474,12 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 	var/mutable_appearance/appearance = new
 	appearance.appearance = our_human.appearance
 	appearance.name = ckey
+
 	if(we_created)
 		qdel(our_human)
+
+	qdel(mock_client)
+	qdel(preferences)
 
 	if(!only_appearance)
 		return list(

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1361,7 +1361,7 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 	var/list/job_preferences = SANITIZE_LIST(selected_char?["job_preferences"])
 
 	var/datum/client_interface/mock_client = new /datum/client_interface
-	var/datum/preferences/preferences = new(mock_client)
+	var/datum/preferences/preferences = new(mock_client, TRUE)
 
 	for (var/datum/preference/preference as anything in get_preferences_in_priority_order())
 		var/saved_data = selected_char?[preference.savefile_key]
@@ -1422,9 +1422,9 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 		var/saved_data = selected_char?[preference.savefile_key]
 		if(!saved_data)
 			continue
-		var/new_value = preference.deserialize(saved_data)
+		var/new_value = preference.deserialize(saved_data, preferences)
 
-		preference.apply_to_human(our_human, new_value)
+		preference.apply_to_human(our_human, new_value, preferences)
 
 	our_human.icon_render_keys = list()
 	our_human.update_body(is_creating = TRUE)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -107,8 +107,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	value_cache = null
 	return ..()
 
-/datum/preferences/New(client/parent)
+/datum/preferences/New(client/parent, do_not_save = FALSE)
 	src.parent = parent
+	if(do_not_save)
+		load_and_save = FALSE
 
 	for (var/middleware_type in subtypesof(/datum/preference_middleware))
 		middleware += new middleware_type(src)

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -1,5 +1,8 @@
 /// Fully randomizes everything in the character.
 /datum/preferences/proc/randomise_appearance_prefs(randomize_flags = ALL)
+	var/tree_key = "character[default_slot]"
+	if(!(tree_key in savefile.get_entry()))
+		savefile.set_entry(tree_key, list())
 	for (var/datum/preference/preference as anything in get_preferences_in_priority_order())
 		if (!preference.included_in_randomization_flags(randomize_flags))
 			continue

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -297,6 +297,7 @@
 #include "reagent_recipe_collisions.dm"
 #include "reagent_transfer.dm"
 #include "recycle_recycling.dm"
+#include "render_offline_appearance.dm"
 #include "required_map_items.dm"
 #include "resist.dm"
 #include "reskin_validation.dm"

--- a/code/modules/unit_tests/render_offline_appearance.dm
+++ b/code/modules/unit_tests/render_offline_appearance.dm
@@ -3,7 +3,7 @@
 
 /datum/unit_test/render_offline_appearance/Run()
 	var/datum/client_interface/our_client = new /datum/client_interface
-	var/datum/preferences/preferences = new(our_client)
+	new /datum/preferences(our_client)
 	var/mutable_appearance/appearance = render_offline_appearance(our_client.ckey)
 	TEST_ASSERT(appearance, "Appearance is not created")
 	TEST_ASSERT(istype(appearance), "Appearance is not mutable_appearance")

--- a/code/modules/unit_tests/render_offline_appearance.dm
+++ b/code/modules/unit_tests/render_offline_appearance.dm
@@ -1,0 +1,9 @@
+/datum/unit_test/render_offline_appearance
+	test_flags = UNIT_TEST_FOCUS
+
+/datum/unit_test/render_offline_appearance/Run()
+	var/datum/client_interface/our_client = new /datum/client_interface
+	var/datum/preferences/preferences = new(our_client)
+	var/mutable_appearance/appearance = render_offline_appearance(our_client.ckey)
+	TEST_ASSERT(appearance, "Appearance is not created")
+	TEST_ASSERT(istype(appearance), "Appearance is not mutable_appearance")


### PR DESCRIPTION

## Pull Request Hakkında

artık apply_to_human için preferences parametresi gerekiyor. o yüzden mock client oluşturup onunla preferences olusturuyoruz, yeni olusturdugumuz preferences mockclient1 diye preferences dosyası kaydetmesin diye yeni parametre ekledim. 

unit testte ise mock client olusturup onun preferencesinden (rastgele üretilen ilk karakter) appearance olusturuyor.
## Oyun İçin Neden Gerekli

Daha az hata 
## Changelog
Oyuncuları ilgilendirmiyor
